### PR TITLE
Generate `types.dart` via Dart code

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,16 +1,15 @@
-# Dart Validation Code Generator
+# Dart Code Generator
 
-A command line tool which generates validation code for protobuf code basing on the validation
-options from `spine/options.proto`.
+A command line tool which generates Dart code for Protobuf type registries.
 
 ## Usage 
 
 The generator accepts several command line arguments:
  - Required option `--descriptor` specifies the path to a file which contains
    a `google.protobuf.FileDescriptorSet`. The descriptor set contains all the Protobuf types
-   for which the tool must generate validation code.
- - Required option `--destination` specifies the path to the file into which the validation code
-   must be written. If the file does not exist, it is created.
+   for which the tool must generate code.
+ - Required option `--destination` specifies the path to the file into which the code must be 
+   written. If the file does not exist, it is created.
  - Option `--standard-types` specifies a Dart package which contains standard Protobuf types. 
    The default value of this option is `spine_client`. The package should contain types:
      - declared in the `google.protobuf.*` package;

--- a/codegen/bin/main.dart
+++ b/codegen/bin/main.dart
@@ -64,7 +64,7 @@ void _launch_code_gen(ArgResults args) {
 
     FileDescriptorSet descriptors = _parseDescriptors(descFile);
     var properties = dart_code_gen.Properties(descriptors, stdPackage, importPrefix);
-    var dartCode = dart_code_gen.generateValidators(properties);
+    var dartCode = dart_code_gen.generate(properties);
     destinationFile.writeAsStringSync(dartCode, flush: true);
     if (shouldPrint) {
         stdout.write(dartCode);

--- a/codegen/bin/main.dart
+++ b/codegen/bin/main.dart
@@ -34,15 +34,15 @@ const String importPrefixArgument = 'import-prefix';
 const String stdoutFlag = 'stdout';
 const String helpFlag = 'help';
 
-/// Launches the Dart validation code generator.
+/// Launches the Dart code generator.
 ///
 main(List<String> arguments) {
     ArgParser parser = _createParser();
     var args = parser.parse(arguments);
     var help = args[helpFlag];
     if (help) {
-        stdout.writeln('dart_code_gen — a command line application for generating Dart validation '
-                       'code based on Spine validation options.');
+        stdout.writeln('dart_code_gen — a command line application for generating Dart type '
+                       'registries and validation code.');
         stdout.writeln(parser.usage);
     } else {
         _launch_code_gen(args);

--- a/codegen/lib/dart_code_gen.dart
+++ b/codegen/lib/dart_code_gen.dart
@@ -21,8 +21,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_code_gen/google/protobuf/descriptor.pb.dart';
 import 'package:dart_code_gen/src/constraint_violation.dart';
-import 'package:dart_code_gen/src/imports.dart';
-import 'package:dart_code_gen/src/validator_factory.dart';
 import 'package:dart_style/dart_style.dart';
 
 import 'src/known_types_factory.dart';

--- a/codegen/lib/dart_code_gen.dart
+++ b/codegen/lib/dart_code_gen.dart
@@ -41,7 +41,7 @@ class Properties {
     Properties(this.types, this.standardPackage, this.importPrefix);
 }
 
-/// Generates the message validators and obtains their Dart source code.
+/// Generates a helper library which works with Protobuf message types compiled into Dart.
 String generate(Properties properties) {
     var knownTypes = KnownTypesFactory(properties);
     var code = Library((b) =>

--- a/codegen/lib/dart_code_gen.dart
+++ b/codegen/lib/dart_code_gen.dart
@@ -90,7 +90,3 @@ Field _createTypeUrlToInfoMap(Properties properties) {
 Field _createMessageToTypeUrlMap(Properties properties) {
 
 }
-
-Class _createKnownTypesPartClass(Properties properties) {
-
-}

--- a/codegen/lib/src/known_types_factory.dart
+++ b/codegen/lib/src/known_types_factory.dart
@@ -147,4 +147,3 @@ class KnownTypesFactory {
             ..symbol = 'Map'
             ..types.addAll([keyType, valueType]));
 }
-

--- a/codegen/lib/src/known_types_factory.dart
+++ b/codegen/lib/src/known_types_factory.dart
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_code_gen/dart_code_gen.dart';
+import 'package:dart_code_gen/src/imports.dart';
+
+const _typeUrlToInfo = 'typeUrlToInfo';
+const _defaultToTypeUrl = 'defaultToTypeUrl';
+const _validators = 'validators';
+
+const _knownTypesPart = '_KnownTypesPart';
+
+class KnownTypesFactory {
+
+    final Properties _properties;
+
+    KnownTypesFactory(this._properties);
+
+    Class generateClass() {
+        var builderInfoType = refer('BuilderInfo', protobufImport);
+        var generatedMessageType = refer('GeneratedMessage', protobufImport);
+        var stringType = refer('String');
+        var errorImport = validationErrorImport(_properties.standardPackage);
+        var validationErrorType = refer('ValidationError', errorImport);
+        var validatorFunctionType = FunctionType((b) => b
+            ..requiredParameters.add(generatedMessageType)
+            ..returnType = validationErrorType);
+        
+        var typeUrlToInfo = Field((b) => b
+            ..name = _typeUrlToInfo
+            ..type = _mapType(stringType, builderInfoType));
+        var defaultToTypeUrl = Field((b) => b
+            ..name = _defaultToTypeUrl
+            ..type = _mapType(generatedMessageType, stringType));
+        var validators = Field((b) => b
+            ..name = _validators
+            ..type = _mapType(stringType, validatorFunctionType));
+        
+        Constructor ctor = Constructor((b) => b
+            ..requiredParameters.addAll([_initParam(_typeUrlToInfo),
+                                         _initParam(_defaultToTypeUrl),
+                                         _initParam(_validators)])
+        );
+        return Class((b) { b
+                ..name = _knownTypesPart
+                ..constructors.add(ctor)
+                ..fields.addAll([typeUrlToInfo, defaultToTypeUrl, validators]);
+        });
+    }
+
+    Method generateAccessor() {
+        var ctorCall = refer(_knownTypesPart).newInstance([refer(_typeUrlToInfo),
+                                                           refer(_defaultToTypeUrl),
+                                                           refer(_validators)]);
+        return Method((b) => b
+            ..name = 'types'
+            ..returns = refer('dynamic')
+            ..body = ctorCall.returned.statement
+        );
+    }
+    
+    Parameter _initParam(String name) {
+        return Parameter((b) => b..name = name
+                                 ..toThis = true);
+    }
+
+    Reference _mapType(Reference keyType, Reference valueType) => TypeReference((b) => b
+            ..symbol = 'Map'
+            ..types.addAll([keyType, valueType]));
+}
+

--- a/codegen/lib/src/type.dart
+++ b/codegen/lib/src/type.dart
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import 'package:dart_code_gen/google/protobuf/descriptor.pb.dart';
+
+const _protoExtension = 'proto';
+const _pbDartExtension = 'pb.dart';
+
+class MessageType {
+
+    final FileDescriptorProto file;
+    final DescriptorProto descriptor;
+    final String fullName;
+    final String dartClassName;
+
+    MessageType._(this.file, this.descriptor, this.fullName, this.dartClassName);
+
+    MessageType._fromFile(FileDescriptorProto file, DescriptorProto descriptor)
+        :
+            file = file,
+            descriptor = descriptor,
+            fullName = _fullName(file, descriptor),
+            dartClassName = descriptor.name;
+
+    static String _fullName(FileDescriptorProto file, DescriptorProto descriptor) =>
+        "${file.package}.${descriptor.name}";
+
+    TypeSet allChildDeclarations() {
+        var children = <MessageType>{};
+        for (var child in _nestedDeclarations()) {
+            children.add(child);
+            children.addAll(child
+                                .allChildDeclarations()
+                                .types);
+        }
+        return TypeSet._(children);
+    }
+
+    String get dartFilePath {
+        var protoFilePath = file.name;
+        var extensionIndex = protoFilePath.length - _protoExtension.length;
+        var dartPath = protoFilePath.substring(0, extensionIndex) + _pbDartExtension;
+        return dartPath;
+    }
+
+    Iterable<MessageType> _nestedDeclarations() {
+        return descriptor.nestedType
+            .map((desc) => _child(desc));
+    }
+
+    MessageType _child(DescriptorProto descriptor) {
+        var name = descriptor.name;
+        return MessageType._(file, descriptor, _childName(name), _childDartName(name));
+    }
+
+    String _childName(String simpleName) {
+        return '${fullName}.${simpleName}';
+    }
+
+    String _childDartName(String simpleName) {
+        return '${fullName}_${simpleName}';
+    }
+}
+
+class TypeSet {
+
+    final Set<MessageType> types;
+
+    TypeSet._(this.types);
+
+    factory TypeSet.of(FileDescriptorSet fileSet) {
+        var typeSet = <MessageType>{};
+        var files = fileSet.file;
+        for (var file in files) {
+            for (var type in file.messageType) {
+                var messageType = MessageType._fromFile(file, type);
+                typeSet.add(messageType);
+                typeSet.addAll(messageType.allChildDeclarations().types);
+            }
+        }
+        return TypeSet._(typeSet);
+    }
+}

--- a/codegen/lib/src/type.dart
+++ b/codegen/lib/src/type.dart
@@ -99,11 +99,10 @@ class MessageType {
 
     MessageType _child(DescriptorProto descriptor) {
         var name = descriptor.name;
-
-        return MessageType._(file, descriptor, _childName(name), _childDartName(name));
+        return MessageType._(file, descriptor, _childProtoName(name), _childDartName(name));
     }
 
-    String _childName(String simpleName) {
+    String _childProtoName(String simpleName) {
         return '${fullName}.${simpleName}';
     }
 

--- a/codegen/lib/src/validator_factory.dart
+++ b/codegen/lib/src/validator_factory.dart
@@ -44,10 +44,9 @@ class ValidatorFactory {
 
     final FileDescriptorProto file;
     final DescriptorProto type;
-    final Allocator allocator;
     final Properties properties;
 
-    ValidatorFactory(this.file, this.type, this.allocator, this.properties);
+    ValidatorFactory(this.file, this.type, this.properties);
 
     String get fullTypeName => '${file.package}.${type.name}';
 

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_code_gen
-description: A command line application for generating validation code based on Spine validation options.
+description: A command line tool which generates Dart code for Protobuf type registries.
 version: 0.1.0
 homepage: https://spine.io
 author: Spine Event Engine <spine-developers@teamdev.com>

--- a/codegen/test/validation_test.dart
+++ b/codegen/test/validation_test.dart
@@ -226,7 +226,8 @@ void assertInvalid(GeneratedMessage message) {
 }
 
 List<ConstraintViolation> validate(GeneratedMessage message) {
-    var doValidate = validators[message.info_.qualifiedMessageName];
+    var typeUrl = types().defaultToTypeUrl[message.createEmptyInstance()];
+    var doValidate = types().validators[typeUrl];
     var error = doValidate(message);
     return error.constraintViolation;
 }


### PR DESCRIPTION
Starting with this PR we generate the Dart type registries (a.k.a. `types.dart`) via the command line tool which we already use to generate validators. Previously, those registries used to be generated via the Spine Protobuf Dart Gradle plugin.

Also, the `validators.dart` and `types.dart` files are merged so that there is only one generated file in a user's Dart module.