### PR TITLE
Dart publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+How to contribute
+==================
+Thank you for wanting to contribute to Spine. The following links will help you get started:
+ * [Wiki home][wiki-home] — the home of the framework developer's documentation.
+ * [Getting started with Spine in Java][quick-start] — this guide will walk you through
+   a minimal client-server “Hello World!” application in Java. 
+ * [Introduction][docs-intro] — this section of the Spine Documentation will help you understand
+   the foundation of the framework.
+   
+Pull requests
+-------------
+The work on an improvement starts with creating an issue that describes a bug or a feature. The issue will be used for communications on the proposed improvements. 
+If code changes are going to be introduced, the issue should also have a link to the corresponding Pull Request.
+
+Code contributions should:
+  * Be accompanied by tests.
+  * Be licensed under the Apache v2.0 license with the appropriate copyright header for each file.
+  * Formatted according to the code style. See [Wiki home][wiki-home] for the links to
+    style guides of the programming languages used in the framework.  
+
+Contributor License Agreement
+-----------------------------
+Contributions to the code of Spine Event Engine framework and its libraries must be accompanied by
+Contributor License Agreement (CLA).
+
+ * If you are an individual writing original source code and you're sure you own
+   the intellectual property, then you'll need to sign an individual CLA.
+   
+ * If you work for a company which wants you to contribute your work,
+   then an authorized person from your company will need to sign a corporate CLA.
+
+Please [contact us][legal-email] for arranging the paper formalities.
+   
+[wiki-home]: https://github.com/SpineEventEngine/SpineEventEngine.github.io/wiki
+[quick-start]: https://spine.io/docs/quick-start
+[docs-intro]: https://spine.io/docs/introduction
+[legal-email]: mailto:legal@teamdev.com

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -27,6 +27,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import java.io.FileNotFoundException
 import java.net.URL
 
 /**
@@ -52,13 +53,13 @@ open class CheckVersionIncrement : DefaultTask() {
         val artifact = "${project.artifactPath()}/${MavenMetadata.FILE_NAME}"
         val repoUrl = repository.releases
         val metadata = fetch(repoUrl, artifact)
-        val versions = metadata.versioning.versions
-        val versionExists = versions.contains(version)
+        val versions = metadata?.versioning?.versions
+        val versionExists = versions?.contains(version) ?: false
         if (versionExists) {
             throw GradleException("""
                     Version `$version` is already published to maven repository `$repoUrl`.
                     Try incrementing the library version.
-                    All available versions are: ${versions.joinToString(separator = ", ")}. 
+                    All available versions are: ${versions?.joinToString(separator = ", ")}. 
                     
                     To disable this check, run Gradle with `-x $name`. 
                     """.trimIndent()
@@ -66,7 +67,7 @@ open class CheckVersionIncrement : DefaultTask() {
         }
     }
 
-    private fun fetch(repository: String, artifact: String): MavenMetadata {
+    private fun fetch(repository: String, artifact: String): MavenMetadata? {
         val url = URL("$repository/$artifact")
         return MavenMetadata.fetchAndParse(url)
     }
@@ -94,9 +95,19 @@ private data class MavenMetadata(var versioning: Versioning = Versioning()) {
             mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
         }
 
-        fun fetchAndParse(url: URL): MavenMetadata {
-            val metadata = mapper.readValue(url, MavenMetadata::class.java)
-            return metadata
+        /**
+         * Fetches the metadata for the repository and parses the document.
+         *
+         * <p>If the document could not be found, assumes that the module was never
+         * released and thus has no metadata.
+         */
+        fun fetchAndParse(url: URL): MavenMetadata? {
+            return try {
+                val metadata = mapper.readValue(url, MavenMetadata::class.java)
+                metadata
+            } catch (e: FileNotFoundException) {
+                null
+            }
         }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -70,8 +70,8 @@ object Versions {
     val checkerFramework = "3.3.0"
     val errorProne       = "2.3.4"
     val errorProneJavac  = "9+181-r4173-1" // taken from here: https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
-    val errorPronePlugin = "1.1.1"
-    val pmd              = "6.20.0"
+    val errorPronePlugin = "1.2.1"
+    val pmd              = "6.24.0"
     val checkstyle       = "8.29"
     val protobufPlugin   = "0.8.12"
     val appengineApi     = "1.9.79"
@@ -94,14 +94,19 @@ object Versions {
     val javaPoet         = "1.12.1"
     val autoService      = "1.0-rc6"
     val autoCommon       = "0.10"
-    val jackson          = "2.9.10.4"
+    val jackson          = "2.9.10.5"
     val animalSniffer    = "1.18"
     val apiguardian      = "1.1.0"
+    val javaxAnnotation  = "1.3.2"
+    val klaxon           = "5.4"
+    val ouathJwt         = "3.10.3"
+    val bouncyCastlePkcs = "1.66"
+    val assertK          = "0.22"
 
     /**
      * Version of the SLF4J library.
      *
-     * Spine used to log with SLF4J. Now we use Flogger. Whenever a coice comes up, we recommend to
+     * Spine used to log with SLF4J. Now we use Flogger. Whenever a choice comes up, we recommend to
      * use the latter.
      *
      * Some third-party libraries may clash with different versions of the library. Thus, we specify
@@ -158,12 +163,20 @@ object Build {
 
     object AutoService {
         val annotations = "com.google.auto.service:auto-service-annotations:${Versions.autoService}"
-        val processor = "com.google.auto.service:auto-service:${Versions.autoService}"
+        val processor   = "com.google.auto.service:auto-service:${Versions.autoService}"
     }
 }
 
 object Gen {
-    val javaPoet = "com.squareup:javapoet:${Versions.javaPoet}"
+    val javaPoet        = "com.squareup:javapoet:${Versions.javaPoet}"
+    val javaxAnnotation = "javax.annotation:javax.annotation-api:${Versions.javaxAnnotation}"
+}
+
+object Publishing {
+    val klaxon           = "com.beust:klaxon:${Versions.klaxon}"
+    val oauthJwt         = "com.auth0:java-jwt:${Versions.ouathJwt}"
+    val bouncyCastlePkcs = "org.bouncycastle:bcpkix-jdk15on:${Versions.bouncyCastlePkcs}"
+    val assertK          = "com.willowtreeapps.assertk:assertk-jvm:${Versions.assertK}"
 }
 
 object Grpc {
@@ -227,7 +240,7 @@ object Test {
             "com.google.truth.extensions:truth-proto-extension:${Versions.truth}"
     )
     @Deprecated("Use Flogger over SLF4J.",
-                replaceWith = ReplaceWith("Deps.runtime.floggerSystemBackend"))
+            replaceWith = ReplaceWith("Deps.runtime.floggerSystemBackend"))
     @Suppress("DEPRECATION") // Version of SLF4J.
     val slf4j         = "org.slf4j:slf4j-jdk14:${Versions.slf4j}"
 }
@@ -273,6 +286,7 @@ object Deps {
     val test = Test
     val versions = Versions
     val scripts = Scripts
+    val publishing = Publishing
 }
 
 object DependencyResolution {

--- a/client/README.md
+++ b/client/README.md
@@ -101,14 +101,14 @@ for this package.
 
 ### Adding uploader
 
-As a uploader, you may add other uploaders for this package by running:
+As an uploader, you may add other uploaders for this package by running:
 ```shell
 pub uploader --package spine_client add <email>
 ```
 
 ### Removing uploader
 
-As a uploader, you may remove other uploaders for this package by running:
+As an uploader, you may remove other uploaders for this package by running:
 ```shell
 pub uploader --package spine_client remove <email>
 ```

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spine_client
 description: Dart-based library for client applications of Spine-based systems.
-version: 0.1.3
+version: 0.1.5
 homepage: https://spine.io
 
 environment:

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_code_gen
 description: A command line tool which generates Dart code for Protobuf type registries.
-version: 0.1.3
+version: 0.1.5
 homepage: https://spine.io
 
 environment:

--- a/integration-tests/client-test/build.gradle.kts
+++ b/integration-tests/client-test/build.gradle.kts
@@ -18,9 +18,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.apache.tools.ant.taskdefs.condition.Os
-import io.spine.gradle.internal.Deps
 import com.google.protobuf.gradle.*
+import io.spine.gradle.internal.Deps
+import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
     codegen
@@ -30,7 +30,6 @@ plugins {
 
 apply {
     from(Deps.scripts.dartBuildTasks(project))
-    from(Deps.scripts.pubPublishTasks(project))
 }
 
 


### PR DESCRIPTION
This PR addresses errors appearing when publishing Dart packages.

When asked to publish a package, `pub` util tries to get a confirmation from the user in the form of "y" typed into the console. Since we're automating the publishing process, we pass the string into the stdin `InputStream` instead.

The version of the packages is updated to 0.1.5 since 0.1.4 is already published.