### PR TITLE
Ignore a `null` Firebase node

### DIFF
--- a/client/lib/rest_firebase_client.dart
+++ b/client/lib/rest_firebase_client.dart
@@ -47,6 +47,9 @@ class RestClient implements FirebaseClient {
     @override
     Stream<String> get(String path) async* {
         var root = await _client.get(Url.from(_databaseUrl, '${path}.json').stringUrl);
+        if (root == null) {
+            return;
+        }
         for (var element in root.values) {
             yield element.toString();
         }

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spine_client
 description: Dart-based library for client applications of Spine-based systems.
-version: 0.1.7
+version: 0.1.8
 homepage: https://spine.io
 
 environment:

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_code_gen
 description: A command line tool which generates Dart code for Protobuf type registries.
-version: 0.1.7
+version: 0.1.8
 homepage: https://spine.io
 
 environment:


### PR DESCRIPTION
In the current version, the Firebase client crashes if the requested node is absent in the DB. This PR fixes that.