### PR TITLE
Fix CLI tool publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
  - ./gradlew integrationTest
 
 deploy:
-  skip_cleanup: false
+  skip_cleanup: true
   provider: script
   script: bash config/scripts/publish-artifacts.sh
   on:

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -60,7 +60,7 @@ val dartDoc by tasks.creating(Exec::class) {
 
 afterEvaluate {
     extra["generatedDocs"] = files(dartDocDir)
-    tasks["updateGitHubPages"].dependsOn("dartDoc")
+    tasks["updateGitHubPages"].dependsOn(dartDoc)
     tasks["publish"].dependsOn("updateGitHubPages")
 }
 

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spine_client
 description: Dart-based library for client applications of Spine-based systems.
-version: 0.1.8
+version: 0.1.9
 homepage: https://spine.io
 
 environment:

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_code_gen
 description: A command line tool which generates Dart code for Protobuf type registries.
-version: 0.1.8
+version: 0.1.9
 homepage: https://spine.io
 
 environment:

--- a/script/unpack-credentials.sh
+++ b/script/unpack-credentials.sh
@@ -23,7 +23,7 @@
 # Decrypt and unpack credentials:
 #  - spine-dev.json - the Firebase service account to use for integration tests;
 #  - pub-credentials.json - credentials to publish package to Pub;
-#  - deploy_rsa_key - private key for deploying GitHub Pages.
+#  - deploy_key_rsa - private key for deploying GitHub Pages.
 openssl aes-256-cbc -K $encrypted_54891cbed47a_key -iv $encrypted_54891cbed47a_iv -in credentials.tar.enc -out credentials.tar -d
 tar xvf credentials.tar
 mkdir ./integration-tests/test-app/src/main/resources


### PR DESCRIPTION
This PR fixes an error in the publishing script.

The package and doc publishing is started from the Travis `deploy` stage. Previously, Travis was [cleaning up](https://docs.travis-ci.com/user/deployment/#uploading-files-and-skip_cleanup) the working dir before publishing. Now we configure the CI to retain all the changes made to the working dir during the build. This allows us to use the decrypted credentials for publishing Dart doc to GitHub.