### PR TITLE
Custom validation error messages

### DIFF
--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spine_client
 description: Dart-based library for client applications of Spine-based systems.
-version: 0.1.9
+version: 0.2.0
 homepage: https://spine.io
 
 environment:

--- a/client/src/test/proto/spine/test/tools/dart/validation.proto
+++ b/client/src/test/proto/spine/test/tools/dart/validation.proto
@@ -82,7 +82,12 @@ message LotteryTicket {
 
 message TaskId {
 
-    string value = 1 [(required) = true, (pattern).regex = "\\w{20}"];
+    string value = 1 [
+        (required) = true,
+        (if_missing) = {msg_format: 'Task ID must have a value!'},
+        (pattern).regex = "\\w{20}",
+        (pattern).msg_format = 'Task ID must consist of 20 alphanumeric symbols (regx: %s).'
+    ];
 }
 
 // A snapshot of task assignments at a point in time.
@@ -96,7 +101,10 @@ message WorkInProgressSnapshot {
     map<string, TaskId> assignment = 1 [(validate) = true];
 
     // When the snapshot was taken.
-    LocalTime when = 2 [(validate) = true];
+    LocalTime when = 2 [
+        (validate) = true,
+        (if_invalid) = {msg_format: 'WIP snapshot must have a valid timestamp.'}
+    ];
 
     // IDs of tasks which are not yet assigned but are to be done in the nearest future.
     repeated TaskId backlog = 3 [(validate) = true];

--- a/codegen/lib/src/bytes_validator_factory.dart
+++ b/codegen/lib/src/bytes_validator_factory.dart
@@ -18,8 +18,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import 'package:dart_code_gen/google/protobuf/descriptor.pb.dart';
 import 'package:dart_code_gen/src/field_validator_factory.dart';
+import 'package:dart_code_gen/src/type.dart';
 import 'package:dart_code_gen/src/validator_factory.dart';
 
 import 'field_validator_factory.dart';
@@ -29,7 +29,7 @@ import 'validator_factory.dart';
 ///
 class BytesValidatorFactory extends SingularFieldValidatorFactory {
 
-    BytesValidatorFactory(ValidatorFactory validatorFactory, FieldDescriptorProto field)
+    BytesValidatorFactory(ValidatorFactory validatorFactory, FieldDeclaration field)
         : super(validatorFactory, field);
 
     @override

--- a/codegen/lib/src/constraint_violation.dart
+++ b/codegen/lib/src/constraint_violation.dart
@@ -38,6 +38,7 @@ const violationRef = Reference(_violation);
 
 const actualValueArg = 'actualValue';
 const childConstraintsArg = 'childConstraints';
+const paramsArg = 'params';
 
 Reference violationTypeRef(String standardPackage) =>
     Reference(_violationType, validationErrorImport(standardPackage));
@@ -82,6 +83,12 @@ createViolationFactory(String standardPackage) {
             ..type = listOfViolations
             ..name = childConstraintsArg
         );
+        var formatParamsParam = Parameter((b) => b
+            ..named = true
+            ..name = paramsArg
+            ..type = listOfStrings
+            ..defaultTo = Code('const []')
+        );
         b.name = _violation;
         b.requiredParameters
             ..add(Parameter((b) => b..type = refer('String')..name = msgFormat))
@@ -89,7 +96,8 @@ createViolationFactory(String standardPackage) {
             ..add(fieldPathParam);
         b.optionalParameters
             ..add(actualValueParam)
-            ..add(childConstraintsParam);
+            ..add(childConstraintsParam)
+            ..add(formatParamsParam);
         var path = 'path';
         var type = violationTypeRef(standardPackage);
         b..returns = type
@@ -104,6 +112,7 @@ createViolationFactory(String standardPackage) {
              refer(path).property('fieldName').property('addAll').call([refer(fieldPath)]),
              resultRef.property('fieldPath').assign(refer(path)),
              resultRef.property('fieldValue').assign(actualValueRef),
+             resultRef.property('param').property('addAll').call([refer(paramsArg)]),
              resultRef.returned
          ].map((expression) => expression.statement));
     });

--- a/codegen/lib/src/enum_validator_factory.dart
+++ b/codegen/lib/src/enum_validator_factory.dart
@@ -19,8 +19,8 @@
  */
 
 import 'package:code_builder/code_builder.dart';
-import 'package:dart_code_gen/google/protobuf/descriptor.pb.dart';
 import 'package:dart_code_gen/src/field_validator_factory.dart';
+import 'package:dart_code_gen/src/type.dart';
 import 'package:dart_code_gen/src/validator_factory.dart';
 
 import 'field_validator_factory.dart';
@@ -33,7 +33,7 @@ const _minNonEmptyEnumValue = 1;
 ///
 class EnumValidatorFactory extends SingularFieldValidatorFactory {
 
-    EnumValidatorFactory(ValidatorFactory validatorFactory, FieldDescriptorProto field)
+    EnumValidatorFactory(ValidatorFactory validatorFactory, FieldDeclaration field)
         : super(validatorFactory, field);
 
     @override

--- a/codegen/lib/src/field_validator_factory.dart
+++ b/codegen/lib/src/field_validator_factory.dart
@@ -97,8 +97,11 @@ class FieldValidatorFactory {
     /// Generates an expression which constructs a `ConstraintViolation` for a missing required
     /// field.
     Expression _requiredMissing() {
-
-        return violationRef.call([literalString('Field must be set.'),
+        var ifMissing = field.getOption(Options.ifMissing);
+        var message = ifMissing
+            .map((val) => val.msgFormat)
+            .orElse('A value must be set.');
+        return violationRef.call([literalString(message),
                                   literalString(validatorFactory.fullTypeName),
                                   literalList([field.protoName])]);
     }
@@ -214,8 +217,8 @@ class RepeatedFieldValidatorFactory extends FieldValidatorFactory {
                     v.property('toSet').call([]).property(length));
             LazyViolation violation = (v) =>
                 violationRef.call([literalString('Collection must be distinct.'),
-                                      literalString(validatorFactory.fullTypeName),
-                                      literalList([field.protoName])]);
+                                   literalString(validatorFactory.fullTypeName),
+                                   literalList([field.protoName])]);
             var distinctRule = newRule(condition, violation);
             return distinctRule._eval(valuesRef);
         } else {

--- a/codegen/lib/src/field_validator_factory.dart
+++ b/codegen/lib/src/field_validator_factory.dart
@@ -22,6 +22,7 @@ import 'package:code_builder/code_builder.dart';
 import 'package:dart_code_gen/google/protobuf/descriptor.pb.dart';
 import 'package:dart_code_gen/spine/options.pb.dart';
 import 'package:dart_code_gen/src/bytes_validator_factory.dart';
+import 'package:dart_code_gen/src/type.dart';
 
 import 'constraint_violation.dart';
 import 'enum_validator_factory.dart';
@@ -38,7 +39,7 @@ class FieldValidatorFactory {
     final ValidatorFactory validatorFactory;
 
     /// The field to validate.
-    final FieldDescriptorProto field;
+    final FieldDeclaration field;
 
     FieldValidatorFactory(this.validatorFactory, this.field);
 
@@ -46,10 +47,9 @@ class FieldValidatorFactory {
     ///
     /// May return `null` to signify that no validation is required for the given field.
     ///
-    factory FieldValidatorFactory.forField(FieldDescriptorProto field, ValidatorFactory factory) {
+    factory FieldValidatorFactory.forField(FieldDeclaration field, ValidatorFactory factory) {
         var singularFactory = SingularFieldValidatorFactory._forType(field, factory);
-        var repeated = field.label == FieldDescriptorProto_Label.LABEL_REPEATED;
-        if (repeated) {
+        if (field.isRepeated) {
             return RepeatedFieldValidatorFactory(factory, field, singularFactory);
         } else {
             return singularFactory;
@@ -69,11 +69,7 @@ class FieldValidatorFactory {
     ///
     /// Returns `true` if the field is required and `false` if it is optional.
     ///
-    bool isRequired() {
-        var options = field.options;
-        return options.hasExtension(Options.required)
-            && options.getExtension(Options.required);
-    }
+    bool isRequired() => field.getOption(Options.required).orElse(false);
 
     /// Determines if this field type supports `(required)` and related constraints.
     ///
@@ -101,9 +97,10 @@ class FieldValidatorFactory {
     /// Generates an expression which constructs a `ConstraintViolation` for a missing required
     /// field.
     Expression _requiredMissing() {
+
         return violationRef.call([literalString('Field must be set.'),
                                   literalString(validatorFactory.fullTypeName),
-                                  literalList([field.name])]);
+                                  literalList([field.protoName])]);
     }
 }
 
@@ -111,12 +108,12 @@ class FieldValidatorFactory {
 ///
 class SingularFieldValidatorFactory extends FieldValidatorFactory {
 
-    SingularFieldValidatorFactory(ValidatorFactory validatorFactory, FieldDescriptorProto field)
+    SingularFieldValidatorFactory(ValidatorFactory validatorFactory, FieldDeclaration field)
         : super(validatorFactory, field);
 
-    factory SingularFieldValidatorFactory._forType(FieldDescriptorProto field,
+    factory SingularFieldValidatorFactory._forType(FieldDeclaration field,
                                                    ValidatorFactory factory) {
-        var type = field.type;
+        var type = field.descriptor.type;
         switch (type) {
             case FieldDescriptorProto_Type.TYPE_STRING:
                 return StringValidatorFactory(factory, field);
@@ -175,7 +172,7 @@ class RepeatedFieldValidatorFactory extends FieldValidatorFactory {
     final FieldValidatorFactory _singular;
 
     RepeatedFieldValidatorFactory(ValidatorFactory validatorFactory,
-                                  FieldDescriptorProto field,
+                                  FieldDeclaration field,
                                   this._singular)
         : super(validatorFactory, field);
 
@@ -186,7 +183,7 @@ class RepeatedFieldValidatorFactory extends FieldValidatorFactory {
             var requiredRule = createRequiredRule();
             validation.add(requiredRule._eval(field));
         }
-        var values = 'values_${this.field.name}';
+        var values = 'values_${this.field.dartName}';
         var valuesRef = refer(values);
         var validateDistinctList = _validateDistinct(valuesRef);
         var validateElements = _validateEachElement(valuesRef);
@@ -210,9 +207,7 @@ class RepeatedFieldValidatorFactory extends FieldValidatorFactory {
     LazyCondition notSetCondition() => (v) => v.property('isEmpty');
 
     Code _validateDistinct(Reference valuesRef) {
-        var options = field.options;
-        var option = Options.distinct;
-        if (options.hasExtension(option) && options.getExtension(option)) {
+        if (field.getOption(Options.distinct).orElse(false)) {
             var length = 'length';
             LazyCondition condition = (v) =>
                 v.property(length).notEqualTo(
@@ -220,7 +215,7 @@ class RepeatedFieldValidatorFactory extends FieldValidatorFactory {
             LazyViolation violation = (v) =>
                 violationRef.call([literalString('Collection must be distinct.'),
                                       literalString(validatorFactory.fullTypeName),
-                                      literalList([field.name])]);
+                                      literalList([field.protoName])]);
             var distinctRule = newRule(condition, violation);
             return distinctRule._eval(valuesRef);
         } else {

--- a/codegen/lib/src/field_validator_factory.dart
+++ b/codegen/lib/src/field_validator_factory.dart
@@ -69,7 +69,7 @@ class FieldValidatorFactory {
     ///
     /// Returns `true` if the field is required and `false` if it is optional.
     ///
-    bool isRequired() => field.getOption(Options.required).orElse(false);
+    bool isRequired() => field.findOption(Options.required).orElse(false);
 
     /// Determines if this field type supports `(required)` and related constraints.
     ///
@@ -97,7 +97,7 @@ class FieldValidatorFactory {
     /// Generates an expression which constructs a `ConstraintViolation` for a missing required
     /// field.
     Expression _requiredMissing() {
-        var ifMissing = field.getOption(Options.ifMissing);
+        var ifMissing = field.findOption(Options.ifMissing);
         var message = ifMissing
             .map((val) => val.msgFormat)
             .orElse('A value must be set.');
@@ -210,7 +210,7 @@ class RepeatedFieldValidatorFactory extends FieldValidatorFactory {
     LazyCondition notSetCondition() => (v) => v.property('isEmpty');
 
     Code _validateDistinct(Reference valuesRef) {
-        if (field.getOption(Options.distinct).orElse(false)) {
+        if (field.findOption(Options.distinct).orElse(false)) {
             var length = 'length';
             LazyCondition condition = (v) =>
                 v.property(length).notEqualTo(

--- a/codegen/lib/src/message_validator_factory.dart
+++ b/codegen/lib/src/message_validator_factory.dart
@@ -19,10 +19,10 @@
  */
 
 import 'package:code_builder/code_builder.dart';
-import 'package:dart_code_gen/google/protobuf/descriptor.pb.dart';
 import 'package:dart_code_gen/spine/options.pb.dart';
 import 'package:dart_code_gen/src/constraint_violation.dart';
 import 'package:dart_code_gen/src/field_validator_factory.dart';
+import 'package:dart_code_gen/src/type.dart';
 import 'package:dart_code_gen/src/validator_factory.dart';
 
 import 'field_validator_factory.dart';
@@ -34,7 +34,7 @@ const String _validateLib = 'package:spine_client/validate.dart';
 ///
 class MessageValidatorFactory extends SingularFieldValidatorFactory {
 
-    MessageValidatorFactory(ValidatorFactory validatorFactory, FieldDescriptorProto field)
+    MessageValidatorFactory(ValidatorFactory validatorFactory, FieldDeclaration field)
         : super(validatorFactory, field);
 
     @override
@@ -54,15 +54,11 @@ class MessageValidatorFactory extends SingularFieldValidatorFactory {
             (v) => v.property('createEmptyInstance').call([]).equalTo(v);
 
     /// Checks if the field should be validated according to the `(validate)` option.
-    bool _shouldValidate() {
-        var options = field.options;
-        return options.hasExtension(Options.validate)
-            && options.getExtension(Options.validate);
-    }
+    bool _shouldValidate() => field.getOption(Options.validate).orElse(false);
 
     /// Constructs a [Rule] for validating the field message value.
     Rule _createValidateRule() {
-        var violationsVar = 'violationsOf_${field.name}';
+        var violationsVar = 'violationsOf_${field.dartName}';
         return newRule((fieldValue) => _isValidExpression(fieldValue, refer(violationsVar)),
                        (fieldValue) => _produceViolation(refer(violationsVar)),
           preparation: (fieldValue) => _produceChildViolations(violationsVar, fieldValue));
@@ -93,7 +89,7 @@ class MessageValidatorFactory extends SingularFieldValidatorFactory {
         return violationRef.call([
             literalString('Field must be valid.'),
             literalString(validatorFactory.fullTypeName),
-            literalList([field.name])
+            literalList([field.protoName])
         ], {
             childConstraintsArg: violationsVar.property('value').property('constraintViolation')
         });

--- a/codegen/lib/src/message_validator_factory.dart
+++ b/codegen/lib/src/message_validator_factory.dart
@@ -86,8 +86,11 @@ class MessageValidatorFactory extends SingularFieldValidatorFactory {
     }
 
     Expression _produceViolation(Expression violationsVar) {
+        var message = field.getOption(Options.ifInvalid)
+                           .map((val) => val.msgFormat)
+                           .orElse('The message must have valid properties.');
         return violationRef.call([
-            literalString('Field must be valid.'),
+            literalString(message),
             literalString(validatorFactory.fullTypeName),
             literalList([field.protoName])
         ], {

--- a/codegen/lib/src/message_validator_factory.dart
+++ b/codegen/lib/src/message_validator_factory.dart
@@ -54,7 +54,7 @@ class MessageValidatorFactory extends SingularFieldValidatorFactory {
             (v) => v.property('createEmptyInstance').call([]).equalTo(v);
 
     /// Checks if the field should be validated according to the `(validate)` option.
-    bool _shouldValidate() => field.getOption(Options.validate).orElse(false);
+    bool _shouldValidate() => field.findOption(Options.validate).orElse(false);
 
     /// Constructs a [Rule] for validating the field message value.
     Rule _createValidateRule() {
@@ -86,7 +86,7 @@ class MessageValidatorFactory extends SingularFieldValidatorFactory {
     }
 
     Expression _produceViolation(Expression violationsVar) {
-        var message = field.getOption(Options.ifInvalid)
+        var message = field.findOption(Options.ifInvalid)
                            .map((val) => val.msgFormat)
                            .orElse('The message must have valid properties.');
         return violationRef.call([

--- a/codegen/lib/src/number_validator_factory.dart
+++ b/codegen/lib/src/number_validator_factory.dart
@@ -52,15 +52,15 @@ class NumberValidatorFactory<N extends num> extends SingularFieldValidatorFactor
     @override
     Iterable<Rule> rules() {
         var rules = <Rule>[];
-        field.getOption(Options.min).ifPresent((val) {
+        field.findOption(Options.min).ifPresent((val) {
             Rule minRule = _minRule(val);
             rules.add(minRule);
         });
-        field.getOption(Options.max).ifPresent((val) {
+        field.findOption(Options.max).ifPresent((val) {
             Rule maxRule = _maxRule(val);
             rules.add(maxRule);
         });
-        field.getOption(Options.range).ifPresent((val) {
+        field.findOption(Options.range).ifPresent((val) {
             Iterable<Rule> rangeRules = _rangeRules(val);
             rules.addAll(rangeRules);
         });

--- a/codegen/lib/src/number_validator_factory.dart
+++ b/codegen/lib/src/number_validator_factory.dart
@@ -18,7 +18,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_code_gen/spine/options.pb.dart';
 import 'package:dart_code_gen/src/type.dart';

--- a/codegen/lib/src/required_field_validation_factory.dart
+++ b/codegen/lib/src/required_field_validation_factory.dart
@@ -19,8 +19,8 @@
  */
 
 import 'package:code_builder/code_builder.dart';
+import 'package:dart_code_gen/src/type.dart';
 
-import '../google/protobuf/descriptor.pb.dart';
 import 'constraint_violation.dart';
 import 'field_validator_factory.dart';
 import 'validator_factory.dart';
@@ -103,7 +103,7 @@ class _Combination {
         return factory.notSetCondition()(fieldAccess);
     }
 
-    FieldValidatorFactory _validatorFactory(FieldDescriptorProto field) {
+    FieldValidatorFactory _validatorFactory(FieldDeclaration field) {
         var factory = FieldValidatorFactory.forField(field, _validator);
         if (factory == null || !factory.supportsRequired()) {
             throw StateError('Field `${_validator.type.fullName}.${field}` cannot be required.');
@@ -111,14 +111,14 @@ class _Combination {
         return factory;
     }
 
-    FieldDescriptorProto _field(String name) {
+    FieldDeclaration _field(String protoName) {
         var type = _validator.type;
-        FieldDescriptorProto field = type
-                .descriptor
-                .field
-                .where((t) => t.name == name)
+        FieldDeclaration field = type
+                .fields
+                .where((t) => t.protoName == protoName)
                 .first;
-        ArgumentError.checkNotNull(field, '`${type.fullName}` does not declare field `${name}`.');
+        ArgumentError.checkNotNull(field,
+                                   '`${type.fullName}` does not declare field `${protoName}`.');
         return field;
     }
 }

--- a/codegen/lib/src/string_validator_factory.dart
+++ b/codegen/lib/src/string_validator_factory.dart
@@ -19,8 +19,8 @@
  */
 
 import 'package:code_builder/code_builder.dart';
-import 'package:dart_code_gen/google/protobuf/descriptor.pb.dart';
 import 'package:dart_code_gen/spine/options.pb.dart';
+import 'package:dart_code_gen/src/type.dart';
 
 import 'constraint_violation.dart';
 import 'field_validator_factory.dart';
@@ -32,20 +32,19 @@ import 'validator_factory.dart';
 ///
 class StringValidatorFactory extends SingularFieldValidatorFactory {
 
-    StringValidatorFactory(ValidatorFactory validatorFactory, FieldDescriptorProto field)
+    StringValidatorFactory(ValidatorFactory validatorFactory, FieldDeclaration field)
         : super(validatorFactory, field);
 
     @override
     Iterable<Rule> rules() {
-        var options = field.options;
         var rules = <Rule>[];
         if (isRequired()) {
             rules.add(createRequiredRule());
         }
-        if (options.hasExtension(Options.pattern)) {
-            Rule rule = _patternRule(options);
+        field.getOption(Options.pattern).ifPresent((val) {
+            Rule rule = _patternRule(val);
             rules.add(rule);
-        }
+        });
         return rules;
     }
 
@@ -58,8 +57,7 @@ class StringValidatorFactory extends SingularFieldValidatorFactory {
     /// the `RegExp` to the string and compares the first match to the value of the initial string.
     /// If the values are identical, the check passes.
     ///
-    Rule _patternRule(FieldOptions options) {
-        PatternOption pattern = options.getExtension(Options.pattern);
+    Rule _patternRule(PatternOption pattern) {
         var rule = newRule((v) => refer('RegExp')
             .newInstance([literalString(pattern.regex, raw: true)])
             .property('stringMatch')
@@ -73,6 +71,6 @@ class StringValidatorFactory extends SingularFieldValidatorFactory {
         var message = 'String must match the regular expression `$pattern`';
         return violationRef.call([literalString(message, raw: true),
                                   literalString(validatorFactory.fullTypeName),
-                                  literalList([field.name])]);
+                                  literalList([field.protoName])]);
     }
 }

--- a/codegen/lib/src/string_validator_factory.dart
+++ b/codegen/lib/src/string_validator_factory.dart
@@ -41,7 +41,7 @@ class StringValidatorFactory extends SingularFieldValidatorFactory {
         if (isRequired()) {
             rules.add(createRequiredRule());
         }
-        field.getOption(Options.pattern).ifPresent((val) {
+        field.findOption(Options.pattern).ifPresent((val) {
             Rule rule = _patternRule(val);
             rules.add(rule);
         });

--- a/codegen/lib/src/string_validator_factory.dart
+++ b/codegen/lib/src/string_validator_factory.dart
@@ -63,14 +63,20 @@ class StringValidatorFactory extends SingularFieldValidatorFactory {
             .property('stringMatch')
             .call([v])
             .notEqualTo(v),
-                           (v) => _patternMismatch(pattern.regex));
+                           (v) => _patternMismatch(pattern));
         return rule;
     }
 
-    Expression _patternMismatch(String pattern) {
-        var message = 'String must match the regular expression `$pattern`';
-        return violationRef.call([literalString(message, raw: true),
-                                  literalString(validatorFactory.fullTypeName),
-                                  literalList([field.protoName])]);
-    }
+    Expression _patternMismatch(PatternOption pattern) {
+        var msgFormat = pattern.msgFormat;
+        var message = msgFormat.isEmpty
+            ? 'The string must match the regular expression `%s`.'
+            : msgFormat;
+        return violationRef.call([
+                literalString(message),
+                literalString(validatorFactory.fullTypeName),
+                literalList([field.protoName])
+            ], {paramsArg: literalList([literalString(pattern.regex, raw: true)])}
+        );
+  }
 }

--- a/codegen/lib/src/type.dart
+++ b/codegen/lib/src/type.dart
@@ -242,11 +242,11 @@ class FieldDeclaration {
         return fullName.substring(start);
     }
 
-    bool hasOption(Extension option) {
-        var ext = descriptor.options;
-        return ext.hasExtension(option);
-    }
-
+    /// Finds the given custom option on the field.
+    ///
+    /// Returns the value of the field or `Optional.empty()` if the option is not defined
+    /// on the field.
+    ///
     Optional<T> getOption<T>(Extension<T> option) {
         var ext = descriptor.options;
         if (ext.hasExtension(option)) {

--- a/codegen/lib/src/type.dart
+++ b/codegen/lib/src/type.dart
@@ -247,7 +247,7 @@ class FieldDeclaration {
     /// Returns the value of the field or `Optional.empty()` if the option is not defined
     /// on the field.
     ///
-    Optional<T> getOption<T>(Extension<T> option) {
+    Optional<T> findOption<T>(Extension<T> option) {
         var ext = descriptor.options;
         if (ext.hasExtension(option)) {
             var value = ext.getExtension(option);

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_code_gen
 description: A command line tool which generates Dart code for Protobuf type registries.
-version: 0.1.9
+version: 0.2.0
 homepage: https://spine.io
 
 environment:

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   fixnum: ^0.10.9
   code_builder: ^3.2.0
   dart_style: 1.3.1
+  optional: ^3.1.0
 
 dev_dependencies:
   pedantic: ^1.8.0


### PR DESCRIPTION
In this PR we change validation code generation in order to allow using custom violation messages. Previously, custom violation messages were ignored in Dart.

**Example:**
```proto
message TaskId {

    string value = 1 [
        (required) = true,
        (if_missing) = {msg_format: 'Task ID must have a value!'},
        (pattern).regex = "\\w{20}",
        (pattern).msg_format = 'Task ID must consist of 20 alphanumeric symbols (regx: %s).'
    ];
}
```

If the `TaskId.value` is missing, the message from `(if_missing)` is used instead of the default one.
If the `TaskId.value` does not match the pattern, the message from `(pattern).msg_format` is used instead of the default one.