### PR TITLE
Dart client library release

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -26,3 +26,9 @@
 
  It is expected that, after a testing stage, this API will soon be finalized, and the library —
  promoted to "production-ready".
+
+## 1.7.0
+
+ The first production release of the client library.
+ Starting from now, the Dart lib API is treated as production level. This means a certain level of
+ API stability, as compared to the pre-release non-stable API of versions `0.2.2` and older.

--- a/client/lib/client.dart
+++ b/client/lib/client.dart
@@ -409,7 +409,7 @@ class CommandRequest<M extends GeneratedMessage> {
     /// messages.
     ///
     ///
-    Stream<E> observeEvents<E extends GeneratedMessage>(Type prototype) =>
+    Stream<E> observeEvents<E extends GeneratedMessage>() =>
         _observeEvents<E>().eventMessages;
 
     /// Creates an event subscription for events produced as a direct result of this command.

--- a/client/lib/client.dart
+++ b/client/lib/client.dart
@@ -244,7 +244,6 @@ class Client {
     /// Constructs a request to create an event subscription.
     EventSubscriptionRequest<M> subscribeToEvents<M extends GeneratedMessage>() {
         var type = M;
-        print(type);
         return EventSubscriptionRequest._(this, type);
     }
 

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spine_client
 description: Dart-based library for client applications of Spine-based systems.
-version: 0.2.2
+version: 1.7.0
 homepage: https://spine.io
 
 environment:

--- a/client/test/any_packer_test.dart
+++ b/client/test/any_packer_test.dart
@@ -53,7 +53,6 @@ void main() {
         test('convert int IDs to Any', () {
             var rawId = 42;
             var anyId = packId(rawId);
-            print(unpack(anyId).info_.messageName);
             expect(unpack(anyId), isA<Int32Value>());
             expect((unpack(anyId) as Int32Value).value, equals(rawId));
         });

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,10 +1,10 @@
 # Dart Code Generator
 
-A command line tool which generates Dart code for Protobuf type registries.
+A command-line tool which generates Dart code for Protobuf type registries.
 
 ## Usage 
 
-The generator accepts several command line arguments:
+The generator accepts several command-line arguments:
  - Required option `--descriptor` specifies the path to a file which contains
    a `google.protobuf.FileDescriptorSet`. The descriptor set contains all the Protobuf types
    for which the tool must generate code.

--- a/codegen/bin/main.dart
+++ b/codegen/bin/main.dart
@@ -47,7 +47,7 @@ main(List<String> arguments) {
     var args = parser.parse(arguments);
     var help = args[helpFlag];
     if (help) {
-        stdout.writeln('dart_code_gen — a command line application for generating Dart type '
+        stdout.writeln('dart_code_gen — a command-line application for generating Dart type '
                        'registries and validation code.');
         stdout.writeln(parser.usage);
     } else {

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_code_gen
 description: A command line tool which generates Dart code for Protobuf type registries.
-version: 0.2.2
+version: 1.7.0
 homepage: https://spine.io
 
 environment:

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_code_gen
-description: A command line tool which generates Dart code for Protobuf type registries.
+description: A command-line tool which generates Dart code for Protobuf type registries.
 version: 1.7.0
 homepage: https://spine.io
 

--- a/integration-tests/client-test/integration-test/client_test.dart
+++ b/integration-tests/client-test/integration-test/client_test.dart
@@ -143,7 +143,7 @@ void main() {
                 ..name = 'Task name 3'
                 ..description = 'subscription test';
             var createTaskRequest = client.command(createTaskCmd);
-            var taskCreatedEvents = createTaskRequest.observeEvents<TaskCreated>(TaskCreated);
+            var taskCreatedEvents = createTaskRequest.observeEvents<TaskCreated>();
             createTaskRequest.post();
 
             var newTaskEvent = await taskCreatedEvents.first;

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,6 +29,6 @@
  * already in the root directory.
  */
 
-val spineBaseVersion: String by extra("1.6.16")
-val spineWebVersion: String by extra("1.6.17")
-val versionToPublish: String by extra("1.6.17")
+val spineBaseVersion: String by extra("1.7.0")
+val spineWebVersion: String by extra("1.7.0")
+val versionToPublish: String by extra("1.7.0")


### PR DESCRIPTION
With this PR we finalize the Dart client library API.

Minor API improvements performed after [testing](https://github.com/spine-examples/blog/pull/39) the lib on an example project.

The new version is 1.7.0, catching up with the versions of other framework components.