### PR TITLE
Revert copyright change

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -32,3 +32,8 @@
  The first production release of the client library.
  Starting from now, the Dart lib API is treated as production level. This means a certain level of
  API stability, as compared to the pre-release non-stable API of versions `0.2.2` and older.
+
+## 1.7.2
+
+ The required language level is bumped to `2.7.0` or above (previous was `2.5.0` or above). Now
+ the language features used in the companion CLI tool match the expected level.

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spine_client
 description: Dart-based library for client applications of Spine-based systems.
-version: 1.7.1
+version: 1.7.2
 homepage: https://spine.io
 
 environment:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.7.2
 homepage: https://spine.io
 
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
   protobuf: ^1.0.0

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.7.2
 homepage: https://spine.io
 
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
   args: 1.5.2

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_code_gen
 description: A command-line tool which generates Dart code for Protobuf type registries.
-version: 1.7.1
+version: 1.7.2
 homepage: https://spine.io
 
 environment:

--- a/gradlew
+++ b/gradlew
@@ -1,29 +1,19 @@
 #!/usr/bin/env sh
 
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2015 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
-# Redistribution and use in source and/or binary forms, with or without
-# modification, must retain the above copyright notice and the following
-# disclaimer.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 ##############################################################################


### PR DESCRIPTION
This PR reverts an accidental change of the copyright notice in the `gradlew` file. 

Also, the publication of the library failed due to a mismatch of the target language level. The required language level is bumped to `2.7.0`.