### PR TITLE
Null safety

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -55,5 +55,6 @@ pull text eol=lf
 *.scpt binary
 *.scssc binary
 
-# Encoded files
+# Encrypted files
 *.enc binary
+*.gpg binary

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -46,9 +46,6 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
-    <XML>
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-    </XML>
     <codeStyleSettings language="Dart">
       <option name="RIGHT_MARGIN" value="100" />
       <indentOptions>
@@ -79,6 +76,8 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="BUILDER_METHODS" value="newBuilder,builder,toBuilder,create" />
+      <option name="KEEP_BUILDER_METHODS_INDENTS" value="true" />
       <arrangement>
         <groups>
           <group>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -105,6 +105,9 @@
     <inspection_tool class="ClassIndependentOfModule" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ClassLoaderInstantiation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ClassMayBeInterface" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ClassName" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="Tests" level="WEAK WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="ClassNameDiffersFromFileName" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ClassNameSameAsAncestorName" enabled="true" level="INFO" enabled_by_default="true" />
     <inspection_tool class="ClassNamingConvention" enabled="true" level="INFO" enabled_by_default="true">
@@ -734,6 +737,9 @@
     </inspection_tool>
     <inspection_tool class="ThrowCaughtLocally" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreRethrownExceptions" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ThrowableNotThrown" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="ThrowablePrintStackTrace" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThrownExceptionsPerMethod" enabled="true" level="WARNING" enabled_by_default="true">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="5">
+      <item index="0" class="java.lang.String" itemvalue="io.spine.core.Subscribe" />
+      <item index="1" class="java.lang.String" itemvalue="io.spine.server.aggregate.Apply" />
+      <item index="2" class="java.lang.String" itemvalue="io.spine.server.command.Assign" />
+      <item index="3" class="java.lang.String" itemvalue="io.spine.server.command.Command" />
+      <item index="4" class="java.lang.String" itemvalue="io.spine.server.event.React" />
+    </list>
+  </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
@@ -7,48 +17,26 @@
     <option name="languageLevel" value="ES6" />
   </component>
   <component name="NullableNotNullManager">
-    <option name="myDefaultNullable" value="org.jetbrains.annotations.Nullable" />
-    <option name="myDefaultNotNull" value="org.jetbrains.annotations.NotNull" />
+    <option name="myDefaultNullable" value="org.checkerframework.checker.nullness.qual.Nullable" />
+    <option name="myDefaultNotNull" value="org.checkerframework.checker.nullness.qual.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="14">
-          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
-          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
-          <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
-          <item index="3" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
-          <item index="4" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
-          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
-          <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
-          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
-          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
-          <item index="9" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
-          <item index="10" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
-          <item index="11" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
-          <item index="12" class="java.lang.String" itemvalue="io.reactivex.annotations.Nullable" />
-          <item index="13" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.Nullable" />
+        <list size="3">
+          <item index="1" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="3" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="14">
-          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
-          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
-          <item index="2" class="java.lang.String" itemvalue="javax.validation.constraints.NotNull" />
-          <item index="3" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
-          <item index="4" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
-          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
-          <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
-          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
-          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
-          <item index="9" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
-          <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
-          <item index="11" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
-          <item index="12" class="java.lang.String" itemvalue="io.reactivex.annotations.NonNull" />
-          <item index="13" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.NonNull" />
+        <list size="3">
+          <item index="1" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="3" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
         </list>
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,12 +25,13 @@
  */
 
 import io.spine.gradle.internal.DependencyResolution
+import io.spine.gradle.internal.Repos
 
 buildscript {
 
     // As long as `buildscript` section is always evaluated first,
     // we need to apply explicitly here.
-    apply(from = "$rootDir/config/gradle/dependencies.gradle")
+    apply(from = "$rootDir/buildSrc/src/main/groovy/dependencies.gradle")
     apply(from = "$rootDir/version.gradle.kts")
 
     @Suppress("RemoveRedundantQualifierName") // Cannot use imports here.
@@ -40,6 +41,14 @@ buildscript {
     val spineBaseVersion: String by extra
 
     resolution.defaultRepositories(repositories)
+
+    repositories {
+        repositories.maven {
+            @Suppress("RemoveRedundantQualifierName") // Cannot use imports here.
+            url = uri(io.spine.gradle.internal.Repos.spineSnapshots)
+        }
+    }
+
     dependencies {
         classpath(deps.build.gradlePlugins.protobuf)
         classpath("io.spine.tools:spine-proto-dart-plugin:$spineBaseVersion")
@@ -53,6 +62,12 @@ allprojects {
     apply(from = "$rootDir/version.gradle.kts")
 
     DependencyResolution.defaultRepositories(repositories)
+
+    repositories {
+        repositories.maven {
+            url = uri(Repos.spineSnapshots)
+        }
+    }
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ buildscript {
 
     dependencies {
         classpath(deps.build.gradlePlugins.protobuf)
-        classpath("io.spine.tools:spine-proto-dart-plugin:$spineBaseVersion")
+        classpath("io.spine.tools:spine-mc-dart:$spineBaseVersion")
     }
 
     resolution.forceConfiguration(configurations)
@@ -72,7 +72,7 @@ allprojects {
 
 subprojects {
     apply {
-        plugin("io.spine.tools.proto-dart-plugin")
+        plugin("io.spine.mc-dart")
         plugin("com.google.protobuf")
         plugin("maven-publish")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 
     // As long as `buildscript` section is always evaluated first,
     // we need to apply explicitly here.
-    apply(from = "$rootDir/buildSrc/src/main/groovy/dependencies.gradle")
+    apply(from = "$rootDir/config/gradle/dependencies.gradle")
     apply(from = "$rootDir/version.gradle.kts")
 
     @Suppress("RemoveRedundantQualifierName") // Cannot use imports here.
@@ -51,7 +51,7 @@ buildscript {
 
     dependencies {
         classpath(deps.build.gradlePlugins.protobuf)
-        classpath("io.spine.tools:spine-mc-dart:$spineBaseVersion")
+        classpath("io.spine.tools:spine-proto-dart-plugin:$spineBaseVersion")
     }
 
     resolution.forceConfiguration(configurations)
@@ -72,7 +72,7 @@ allprojects {
 
 subprojects {
     apply {
-        plugin("io.spine.mc-dart")
+        plugin("io.spine.tools.proto-dart-plugin")
         plugin("com.google.protobuf")
         plugin("maven-publish")
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,17 +24,46 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * This script uses three declarations of the constant [licenseReportVersion] because
+ * currently there is no way to define a constant _before_ a build script of `buildSrc`.
+ * We cannot use imports or do something else before the `buildscript` or `plugin` clauses.
+ *
+ * Therefore, when a version of [io.spine.internal.dependency.LicenseReport] changes, it should be
+ * changed in the Kotlin object _and_ in this file below thrice. 
+ */
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    val licenseReportVersion = "1.16"
+    dependencies {
+        classpath("com.github.jk1:gradle-license-report:${licenseReportVersion}")
+    }
+}
+
 plugins {
+    java
+    groovy
     `kotlin-dsl`
+    val licenseReportVersion = "1.16"
+    id("com.github.jk1.dependency-license-report").version(licenseReportVersion)
+}
+
+kotlinDslPluginOptions {
+    experimentalWarning.set(false)
 }
 
 repositories {
     mavenLocal()
-    jcenter()
+    gradlePluginPortal()
+    mavenCentral()
 }
 
 val jacksonVersion = "2.11.0"
+val licenseReportVersion = "1.16"
 
 dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
+    api("com.github.jk1:gradle-license-report:${licenseReportVersion}")
 }

--- a/buildSrc/src/main/groovy/checkstyle.gradle
+++ b/buildSrc/src/main/groovy/checkstyle.gradle
@@ -24,44 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+/*
+ * This script configures Gradle Checkstyle plugin.
+ */
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+import io.spine.internal.dependency.CheckStyle
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
+apply plugin: 'checkstyle'
 
-val spineBaseVersion: String by extra
+checkstyle {
+    toolVersion = "${CheckStyle.version}"
+    configFile = file("$rootDir/config/quality/checkstyle.xml")
 
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+    // Disable checking the test sources.
+    checkstyleTest.enabled = false
 }

--- a/buildSrc/src/main/groovy/dart/build-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/build-tasks.gradle
@@ -24,44 +24,42 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+import org.apache.tools.ant.taskdefs.condition.Os
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
+final def GROUP = 'Dart'
+final def packageIndex = "$projectDir/.packages" as File
+final def extension = Os.isFamily(Os.FAMILY_WINDOWS) ? '.bat' : ''
+final def PUB_EXECUTABLE = 'pub' + extension
+
+task resolveDependencies(type: Exec) {
+    group = GROUP
+    description = 'Fetches the dependencies declared via `pubspec.yaml`.'
+
+    inputs.file "$projectDir/pubspec.yaml"
+    outputs.file packageIndex
+
+    commandLine PUB_EXECUTABLE, 'get'
+
+    mustRunAfter 'cleanPackageIndex'
 }
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
+tasks['assemble'].dependsOn 'resolveDependencies'
+
+task cleanPackageIndex(type: Delete) {
+    group = GROUP
+    description = 'Deletes the `.packages` file on this Dart module.'
+    delete = [packageIndex]
 }
 
-val spineBaseVersion: String by extra
+tasks['clean'].dependsOn 'cleanPackageIndex'
 
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
+task testDart(type: Exec) {
+    group = GROUP
+    description = 'Runs Dart tests declared in the `./test` directory. See `https://pub.dev/packages/test#running-tests`.'
+
+    commandLine PUB_EXECUTABLE, 'run', 'test'
+
+    dependsOn 'resolveDependencies'
 }
 
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
-}
+tasks['check'].dependsOn 'testDart'

--- a/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.apache.tools.ant.taskdefs.condition.Os
+
+final def publicationDir = "$buildDir/pub/publication/$project.name"
+final def extension = Os.isFamily(Os.FAMILY_WINDOWS) ? '.bat' : ''
+final def PUB_EXECUTABLE = 'pub' + extension
+
+task stagePubPublication(type: Copy) {
+    description = 'Prepares the Dart package for Pub publication.'
+
+    from fileTree(projectDir) {
+        include '**/*.dart', 'pubspec.yaml', '**/*.md'
+        exclude 'proto/', 'generated/', 'build/', '**/.*'
+    }
+    from "$rootDir/LICENSE"
+    into publicationDir
+
+    doLast {
+        logger.debug("Prepared Pub publication in directory `$publicationDir`.")
+    }
+
+    dependsOn 'assemble'
+}
+
+/**
+ *  A Dart analog of {@code publish}.
+ */
+task publishToPub(type: Exec) {
+    description = 'Publishes this package to Pub.'
+
+    workingDir publicationDir
+    commandLine PUB_EXECUTABLE, 'publish', '--trace'
+    final sayYes = new ByteArrayInputStream('y'.getBytes())
+    standardInput(sayYes)
+
+    dependsOn 'stagePubPublication'
+}
+
+/**
+ *  A Dart analog of {@code publishToMavenLocal}.
+ */
+task activateLocally(type: Exec) {
+    description = 'Activates this package locally.'
+
+    commandLine PUB_EXECUTABLE, 'global', 'activate', '--source', 'path', publicationDir, '--trace'
+
+    workingDir publicationDir
+    dependsOn 'stagePubPublication'
+}
+
+tasks['publish'].dependsOn 'publishToPub'

--- a/buildSrc/src/main/groovy/dependencies.gradle
+++ b/buildSrc/src/main/groovy/dependencies.gradle
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+//file:noinspection GrDeprecatedAPIUsage
+//file:noinspection UnnecessaryQualifiedReference
+
+/*
+ * This file describes shared dependencies of Spine sub-projects.
+ *
+ * Inspired by dependency management of the Uber's NullAway project:
+ *  https://github.com/uber/NullAway/blob/master/gradle/dependencies.gradle
+ */
+
+// Specific repositories.
+ext.repos = [
+        // Snapshots of Error Prone and Guava.
+        sonatypeSnapshots : 'https://oss.sonatype.org/content/repositories/snapshots',
+        gradlePlugins     : 'https://plugins.gradle.org/m2/'
+]
+
+final def build = [
+        errorProneJavac        : io.spine.internal.dependency.ErrorProne.javacPlugin,
+        errorProneAnnotations  : io.spine.internal.dependency.ErrorProne.INSTANCE.annotations.toArray(),
+        errorProneCheckApi     : io.spine.internal.dependency.ErrorProne.INSTANCE.checkApi,
+        errorProneCore         : io.spine.internal.dependency.ErrorProne.INSTANCE.core,
+        errorProneTestHelpers  : io.spine.internal.dependency.ErrorProne.INSTANCE.testHelpers,
+
+        checkerAnnotations     : io.spine.internal.dependency.CheckerFramework.INSTANCE.annotations,
+        checkerDataflow        : io.spine.internal.dependency.CheckerFramework.INSTANCE.dataflow.toArray(),
+        autoCommon             : io.spine.internal.dependency.AutoCommon.lib,
+        autoService            : [
+                annotations: io.spine.internal.dependency.AutoService.INSTANCE.annotations,
+                processor  : io.spine.internal.dependency.AutoService.processor
+        ],
+
+        jsr305Annotations      : io.spine.internal.dependency.FindBugs.INSTANCE.annotations,
+
+        guava                  : io.spine.internal.dependency.Guava.lib,
+        flogger                : io.spine.internal.dependency.Flogger.lib,
+        slf4j                  : io.spine.internal.dependency.Slf4J.lib,
+        protobuf               : io.spine.internal.dependency.Protobuf.INSTANCE.libs.toArray(),
+        protoc                 : io.spine.internal.dependency.Protobuf.compiler,
+        googleHttpClient       : io.spine.internal.dependency.HttpClient.google,
+        googleHttpClientApache : io.spine.internal.dependency.HttpClient.apache,
+        appengineApi           : io.spine.internal.dependency.AppEngine.sdk,
+
+        firebaseAdmin          : io.spine.internal.dependency.Firebase.admin,
+        jacksonDatabind        : io.spine.internal.dependency.Jackson.databind,
+
+        roasterApi             : io.spine.internal.dependency.Roaster.api,
+        roasterJdt             : io.spine.internal.dependency.Roaster.jdt,
+        animalSniffer          : io.spine.internal.dependency.AnimalSniffer.lib,
+
+        ci: 'true' == System.getenv('CI'),
+
+        gradlePlugins: [
+                errorProne      : io.spine.internal.dependency.ErrorProne.GradlePlugin.lib,
+                protobuf        : io.spine.internal.dependency.Protobuf.GradlePlugin.lib,
+                appengine       : io.spine.internal.dependency.AppEngine.GradlePlugin.lib,
+                licenseReport   : io.spine.internal.dependency.LicenseReport.GradlePlugin.lib
+        ]
+]
+
+final def gen = [
+        javaPoet : io.spine.internal.dependency.JavaPoet.lib
+]
+
+final def grpc = [
+        grpcCore       : io.spine.internal.dependency.Grpc.core,
+        grpcStub       : io.spine.internal.dependency.Grpc.stub,
+        grpcOkHttp     : io.spine.internal.dependency.Grpc.okHttp,
+        grpcProtobuf   : io.spine.internal.dependency.Grpc.protobuf,
+        grpcNetty      : io.spine.internal.dependency.Grpc.netty,
+        grpcNettyShaded: io.spine.internal.dependency.Grpc.nettyShaded,
+        grpcContext    : io.spine.internal.dependency.Grpc.context
+]
+
+final def runtime = [
+        floggerSystemBackend: io.spine.internal.dependency.Flogger.Runtime.systemBackend,
+        floggerLog4J        : io.spine.internal.dependency.Flogger.Runtime.log4J,
+        floggerSlf4J        : io.spine.internal.dependency.Flogger.Runtime.slf4J
+]
+
+final def test = [
+        junit4        : io.spine.internal.dependency.JUnit.legacy,
+        junit5Api     : io.spine.internal.dependency.JUnit.INSTANCE.api.toArray(),
+        junit5Runner  : io.spine.internal.dependency.JUnit.runner,
+        junitPioneer  : io.spine.internal.dependency.JUnit.pioneer,
+        slf4j         : io.spine.internal.dependency.Slf4J.lib,
+        guavaTestlib  : io.spine.internal.dependency.Guava.testLib,
+        truth         : io.spine.internal.dependency.Truth.INSTANCE.libs.toArray()
+]
+
+final def dir = "$rootDir/" + io.spine.internal.gradle.Scripts.commonPath
+final def scripts = [
+        testArtifacts          : "$dir/test-artifacts.gradle",
+        testOutput             : "$dir/test-output.gradle",
+        slowTests              : "$dir/slow-tests.gradle",
+        javadocOptions         : "$dir/javadoc-options.gradle",
+        filterInternalJavadocs : "$dir/filter-internal-javadoc.gradle",
+        jacoco                 : "$dir/jacoco.gradle",
+        publish                : "$dir/publish.gradle",
+        publishProto           : "$dir/publish-proto.gradle",
+        javacArgs              : "$dir/javac-args.gradle",
+        jsBuildTasks           : "$dir/js/build-tasks.gradle",
+        jsConfigureProto       : "$dir/js/configure-proto.gradle",
+        npmPublishTasks        : "$dir/js/npm-publish-tasks.gradle",
+        npmCli                 : "$dir/js/npm-cli.gradle",
+        updatePackageVersion   : "$dir/js/update-package-version.gradle",
+        dartBuildTasks         : "$dir/dart/build-tasks.gradle",
+        pubPublishTasks        : "$dir/dart/pub-publish-tasks.gradle",
+        pmd                    : "$dir/pmd.gradle",
+        checkstyle             : "$dir/checkstyle.gradle",
+        runBuild               : "$dir/run-build.gradle",
+        modelCompiler          : "$dir/model-compiler.gradle",
+        licenseReportCommon    : "$dir/license-report-common.gradle",
+        projectLicenseReport   : "$dir/license-report-project.gradle",
+        repoLicenseReport      : "$dir/license-report-repo.gradle",
+        generatePom            : "$dir/generate-pom.gradle",
+        updateGitHubPages      : "$dir/update-gh-pages.gradle"
+]
+
+ext.deps = [
+        'build'    : build,
+        'grpc'     : grpc,
+        'gen'      : gen,
+        'runtime'  : runtime,
+        'test'     : test,
+        'scripts'  : scripts,
+]
+
+/**
+ * Forces default dependencies for the passed object which has {@code configurations} property.
+ *
+ * <p>Typically this should be applied to {@link ScriptHandler} (if in {@code buildscript} section),
+ * or to {@link Project} (if in project definition section).
+ */
+ext.forceConfiguration = { final configurationContainer ->
+
+    configurationContainer.configurations.all {
+        resolutionStrategy {
+            failOnVersionConflict()
+            cacheChangingModulesFor(0, 'seconds')
+
+            // Force deprecated dependencies.
+            force (Slf4J.lib)
+
+            // Force dependencies internally used by the framework.
+            //noinspection UnnecessaryQualifiedReference
+            force(
+                    io.spine.internal.dependency.ErrorProne.annotations,
+                    io.spine.internal.dependency.JavaX.annotations,
+                    io.spine.internal.dependency.CheckerFramework.annotations,
+                    io.spine.internal.dependency.AutoCommon.lib,
+                    io.spine.internal.dependency.Guava.lib,
+                    io.spine.internal.dependency.AnimalSniffer.lib,
+                    io.spine.internal.dependency.Protobuf.lib,
+                    io.spine.internal.dependency.Guava.testLib,
+                    io.spine.internal.dependency.Truth.lib,
+                    io.spine.internal.dependency.JUnit.INSTANCE.api,
+                    io.spine.internal.dependency.JUnit.legacy,
+                    io.spine.internal.dependency.Protobuf.GradlePlugins.lib,
+            )
+
+            // Force transitive dependencies of 3rd party components that we don't use directly.
+            force(
+                    io.spine.internal.dependency.Gson.lib,
+                    io.spine.internal.dependency.J2ObjC.lib,
+                    io.spine.internal.dependency.Plexus.utils,
+                    io.spine.internal.dependency.Okio.lib,
+                    io.spine.internal.dependency.CommonsCli.lib,
+                    io.spine.internal.dependency.CheckerFramework.compatQual,
+                    io.spine.internal.dependency.CommonsLogging.lib
+            )
+        }
+    }
+}
+
+/**
+ * Adds default repositories to the passed object which has {@code repositories} property.
+ *
+ * <p>Typically this should be applied to {@link ScriptHandler} (if in {@code buildscript} section),
+ * or to {@link Project} (if in project definition section).
+ */
+ext.defaultRepositories = { final repositoryContainer ->
+
+    repositoryContainer.repositories {
+        mavenLocal()
+        maven {
+            url = repos.spine
+            content {
+                includeGroup 'io.spine'
+                includeGroup 'io.spine.tools'
+                includeGroup 'io.spine.gcloud'
+            }
+            mavenContent {
+                releasesOnly()
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}

--- a/buildSrc/src/main/groovy/filter-internal-javadoc.gradle
+++ b/buildSrc/src/main/groovy/filter-internal-javadoc.gradle
@@ -24,44 +24,33 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
-
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
+configurations {
+    excludeInternalDoclet
 }
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
 
 dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
+    /*
+       The variable spineBaseVersion must be defined in the `ext` section of the `version.gradle`
+       file of the project which imports `config` as a sub-module.
+      */
+    excludeInternalDoclet "io.spine.tools:spine-javadoc-filter:$spineBaseVersion"
 }
 
-tasks["testDart"].enabled = false
+// This task uses constants defined in `javadoc-options.gradle`.
+task noInternalJavadoc(type: Javadoc) {
+    source = sourceSets.main.allJava.filter {
+        !it.absolutePath.contains('generated')
+    }
+    classpath = javadoc.getClasspath()
 
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
+    options {
+        tags = javadocOptions.tags
+        encoding = javadocOptions.encoding
+
+        // Doclet fully qualified name.
+        doclet = 'io.spine.tools.javadoc.ExcludeInternalDoclet'
+
+        // Path to the JAR containing the doclet.
+        docletpath = configurations.excludeInternalDoclet.files.asType(List)
     }
 }

--- a/buildSrc/src/main/groovy/generate-pom.gradle
+++ b/buildSrc/src/main/groovy/generate-pom.gradle
@@ -1,0 +1,609 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+//file:noinspection GroovyVariableCanBeFinal
+
+import groovy.xml.MarkupBuilder
+import org.gradle.api.internal.artifacts.dependencies.AbstractExternalModuleDependency
+
+import java.util.function.Function
+
+import static java.util.stream.Collectors.toSet
+
+/**
+ * This script generates a {@code pom.xml} file that contains dependencies of the root project as
+ * well as the dependencies of its subprojects.
+ *
+ * The generated {@code pom.xml} is not usable for {@code maven} build tasks and is merely a
+ * description of project dependencies.
+ *
+ * Configures the {@code build} task to generate the {@code pom.xml} file.
+ *
+ * To generate the pom, {@code apply} from this file.
+ *
+ * Note that the generated {@code pom.xml} includes the group ID, artifact ID and the version of the
+ * project this script was applied to. In case you want to override the default values, do so in
+ * the {@code ext} block like so:
+ *
+ * <pre>
+ * {@code
+ * ext {
+ *     groupId = 'custom-group-id'
+ *     artifactId = 'custom-artifact-id'
+ *     version = 'custom-version'
+ * }
+ * }
+ * </pre>
+ *
+ * By default, those values are taken from the {@code project} object, which may or may not include
+ * them. If the project does not have these values and they are not specified in the {@code ext}
+ * block, the result {@code pom.xml} file is going to contain empty blocks,
+ * e.g. {@code <groupId></groupId>}
+ */
+
+// In some cases, the `base` plugin, which is by default is added by e.g. `java`, is not yet added.
+// `base` plugin defines the `build` task. This script needs it.
+apply plugin: 'base'
+
+ext {
+    pomFile = "${projectDir}${File.separator}pom.xml"
+}
+
+task generatePom {
+
+    doLast {
+        delete pomFile
+        final ExtraPropertiesExtension extension = rootProject.ext
+        final RootProjectData projectData = RootProjectData.fromEither(project, extension)
+        final ProjectPomXml result = ProjectPomXml.from(projectData)
+        result.writeTo(pomFile)
+    }
+}
+
+build.finalizedBy generatePom
+generatePom.dependsOn assemble
+
+/**
+ * A {@code pom.xml} file that contains dependencies of the project and its subprojects.
+ *
+ * <p>It is not usable for {@code maven} build tasks and serves as a description of project first
+ * level dependencies, i.e. transitive dependencies are not included
+ */
+class ProjectPomXml {
+
+    private static final String XML_METADATA = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    private static final String PROJECT_SCHEMA_LOCATION = "<project xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\" xmlns=\"http://maven.apache.org/POM/4.0.0\"" +
+            "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
+    private static final String MODEL_VERSION = "<modelVersion>4.0.0</modelVersion>"
+    private static final String CLOSING_PROJECT_TAG = "</project>"
+    private static final String SPINE_INCEPTION_YEAR = "2015"
+    private static final String NEW_LINE = System.lineSeparator()
+
+    private final Project project
+    private final String groupId
+    private final String artifactId
+    private final String version
+
+    private ProjectPomXml(final Project project,
+                          final String groupId,
+                          final String artifactId,
+                          final String version) {
+        this.project = project
+        this.groupId = groupId
+        this.artifactId = artifactId
+        this.version = version
+    }
+
+    /** Creates a new instance based on the specified project data. */
+    static ProjectPomXml from(final RootProjectData projectData) {
+        return new ProjectPomXml(projectData.project(),
+                projectData.groupId(),
+                projectData.artifactId(),
+                projectData.version())
+    }
+
+    /**
+     * Writes the {@code pom.xml} file containing dependencies of this project and its subprojects to the specified
+     * location.
+     *
+     * <p>If a file with the specified location exists, its contents will be substituted with a new
+     * {@code pom.xml}.
+     *
+     * @param filePath path to write {@code pom.xml} file to
+     */
+    void writeTo(final String filePath) {
+        final FileWriter fileWriter = new FileWriter(filePath)
+        final StringWriter stringWriter = new StringWriter()
+        writeHeader(stringWriter)
+
+        writeBlocks(stringWriter,
+                describingComment(),
+                rootProjectData(),
+                inceptionYear(),
+                licence(),
+                projectDependencies()
+        )
+        fileWriter.write(stringWriter.toString())
+        fileWriter.close()
+    }
+
+    /**
+     * Writes the specified lines using the specified writer, dividing them by platforms line
+     * separator.
+     *
+     * The written lines are also padded with platforms line separator from both sides
+     */
+    static void writeBlocks(final StringWriter writer, final String... lines) {
+        writer.write(NEW_LINE)
+        for (final String line : lines) {
+            writer.write(line)
+            writer.write(NEW_LINE)
+            writer.write(NEW_LINE)
+        }
+        writer.write(NEW_LINE)
+    }
+
+    /**
+     * Obtains a String that represents a tag with the inception year of Spine.
+     */
+    private static String inceptionYear() {
+        final Writer writer = new StringWriter()
+        final MarkupBuilder xmlBuilder = new MarkupBuilder(writer)
+        xmlBuilder.inceptionYear(SPINE_INCEPTION_YEAR)
+        return writer.toString()
+    }
+
+    /**
+     * Obtains licence information about Spine.
+     *
+     * <p>More on licences <a href="https://maven.apache.org/pom.html#Licenses">here</a>.
+     */
+    private static String licence() {
+        final Writer writer = new StringWriter()
+        SpineLicenceAsXml.writeUsing(writer)
+        return writer.toString()
+    }
+
+    /**
+     * Obtains a string that contains project dependencies as XML.
+     *
+     * <p>Obtained string also contains a closing project tag.
+     */
+    private String projectDependencies() {
+        Writer writer = new StringWriter()
+        ProjectDependenciesAsXml projectDeps = ProjectDependenciesAsXml.of(project)
+        projectDeps.writeUsing(writer)
+        writer.write(NEW_LINE)
+        writer.write(CLOSING_PROJECT_TAG)
+        return writer.toString()
+    }
+
+    /**
+     * Obtains a description comment that describes the nature of the generated {@code pom.xml} file.
+     */
+    private static String describingComment() {
+        String description =
+                System.lineSeparator() +
+                        "This file was generated using the Gradle `generatePom` task. " +
+                        System.lineSeparator() +
+                        "This file is not suitable for `maven` build tasks. It only describes the " +
+                        "first-level dependencies of " +
+                        System.lineSeparator() +
+                        "all modules and does not describe the project " +
+                        "structure per-subproject." +
+                        System.lineSeparator()
+        String descriptionComment =
+                String.format("<!-- %s %s %s -->",
+                        System.lineSeparator(),
+                        description,
+                        System.lineSeparator())
+        return descriptionComment
+    }
+
+    /**
+     * Obtains a string that contains the name and the version of the current project.
+     */
+    private String rootProjectData() {
+        Writer writer = new StringWriter()
+        MarkupBuilder xmlBuilder = new MarkupBuilder(writer)
+        xmlBuilder.groupId(this.groupId)
+        xmlBuilder.artifactId(this.artifactId)
+        xmlBuilder.version(this.version)
+        return writer.toString()
+    }
+
+    /**
+     * Writes the XML metadata using the specified writer.
+     */
+    private static void writeHeader(StringWriter stringWriter) {
+        stringWriter.write(XML_METADATA)
+        stringWriter.write(System.lineSeparator())
+        stringWriter.write(PROJECT_SCHEMA_LOCATION)
+        stringWriter.write(System.lineSeparator())
+        stringWriter.write(MODEL_VERSION)
+        stringWriter.write(System.lineSeparator())
+    }
+}
+
+/**
+ * Dependencies of the project expressed as XML.
+ *
+ * <p>Subprojects dependencies are included, transitive dependencies are not included.
+ *
+ * <p>Example:
+ * <pre>
+ * {@code
+ *  <dependencies>
+ *      <dependency>
+ *          <groupId>io.spine</groupId>
+ *          <artifactId>base</artifactId>
+ *          <version>1.0.0-pre7</version>
+ *}
+ * </pre>
+ */
+class ProjectDependenciesAsXml {
+
+    private final Set<DependencyWithScope> firstLevelDependencies
+
+    private ProjectDependenciesAsXml(Set<DependencyWithScope> dependencySet) {
+        this.firstLevelDependencies = new TreeSet<>(dependencySet)
+    }
+
+    /** Creates a new instance based on the specified project. */
+    static ProjectDependenciesAsXml of(Project project) {
+        Set<DependencyWithScope> dependencies = projectDependencies(project)
+        return new ProjectDependenciesAsXml(dependencies)
+    }
+
+    /**
+     * Writes the dependencies using the specified writer.
+     *
+     * <p>Used writer will not be closed.
+     */
+    void writeUsing(Writer writer) {
+        MarkupBuilder xmlBuilder = new MarkupBuilder(writer)
+        xmlBuilder.dependencies() {
+            firstLevelDependencies
+                    .forEach { projectDep ->
+                        xmlBuilder.dependency {
+                            groupId(projectDep.dependency().group)
+                            artifactId(projectDep.dependency().name)
+                            version(projectDep.dependency().version)
+                            if (projectDep.hasDefinedScope()) {
+                                scope(projectDep.scopeName())
+                            }
+                        }
+                    }
+        }
+    }
+
+    private static Set<DependencyWithScope> projectDependencies(Project project) {
+        Set<DependencyWithScope> firstLevelDependencies = new HashSet<>()
+        firstLevelDependencies.addAll(dependenciesFromAllConfigurations(project))
+        project.subprojects.forEach { subproject ->
+            Set<DependencyWithScope> subprojectDeps = dependenciesFromAllConfigurations(subproject)
+            firstLevelDependencies.addAll(subprojectDeps)
+        }
+        return firstLevelDependencies.stream().sorted().distinct().collect(toSet())
+    }
+
+    private static Set<DependencyWithScope> dependenciesFromAllConfigurations(Project project) {
+        Set<DependencyWithScope> result = new HashSet<>()
+        project.configurations.forEach { c ->
+            def configuration = c
+            if (isResolvable(c)) {
+                // Force configuration resolution.
+                configuration.resolvedConfiguration
+            }
+            configuration.dependencies.forEach {
+                if (isExternal(it)) {
+                    DependencyWithScope dependency = DependencyWithScope.of(it, configuration)
+                    result.add(dependency)
+                }
+            }
+        }
+        return result
+    }
+
+    static boolean isResolvable(Configuration config) {
+        config.hasProperty("canBeResolved") && config.canBeResolved
+    }
+
+    private static boolean isExternal(Dependency dependency) {
+        return AbstractExternalModuleDependency.isAssignableFrom(dependency.class)
+    }
+}
+
+/**
+ * A project dependency with its scope.
+ *
+ * @see
+ * <a href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope">
+ *     More on dependency scopes </a>.
+ */
+class DependencyWithScope implements Comparable<DependencyWithScope> {
+
+    private final Dependency dependency
+    private final DependencyScope scope
+
+    /**
+     * A map that contains the relations of known Gradle configuration names
+     * to their Maven dependency scope equivalents.
+     */
+    private static Map<String, DependencyScope> CONFIG_TO_SCOPE
+
+
+    /**
+     * Performs comparison of {@code DependencyWithScope} instances based on the following rules:
+     *
+     * <ul>
+     *     <li>Compares the scope of the dependency first. Dependencies with lower scope
+     *     {@linkplain #dependencyPriority priority} number goes first.
+     *     <li>For dependencies with same scope does the lexicographical group name comparison.
+     *     <li>For dependencies within the same group does the lexicographical artifact
+     *     name comparison.
+     *     <li>For dependencies with the same artifact name does the lexicographical artifact
+     *     version comparison.
+     * </ul>
+     */
+    private static final Comparator<DependencyWithScope> COMPARATOR = Comparator
+            .comparingInt { it.dependencyPriority() }
+            .thenComparing((Function<DependencyWithScope, String>) { it.dependency().group })
+            .thenComparing((Function<DependencyWithScope, String>) { it.dependency().name })
+            .thenComparing((Function<DependencyWithScope, String>) { it.dependency().version })
+
+    static {
+        final DependencyScope compile = DependencyScope.compile
+        final DependencyScope runtime = DependencyScope.runtime
+        final DependencyScope provided = DependencyScope.provided
+
+        CONFIG_TO_SCOPE = new HashMap<>()
+
+        /*
+         * Configurations from the Gradle Java plugin that are known to be mapped to the `compile`
+         * scope.
+         *
+         * Dependencies with the `compile` Maven scope are propagated to dependent projects.
+         *
+         * More at https://docs.gradle.org/current/userguide/java_plugin.html#tab:configurations
+         */
+        CONFIG_TO_SCOPE.put("compile", compile)
+        CONFIG_TO_SCOPE.put("implementation", compile)
+        CONFIG_TO_SCOPE.put("api", compile)
+
+        /*
+         * Configurations from the Gradle Java plugin that are known to be mapped to the `runtime`
+         * scope.
+         *
+         * Dependencies with the `runtime` Maven scopes are required for execution only.
+         */
+        CONFIG_TO_SCOPE.put("runtime", runtime)
+        CONFIG_TO_SCOPE.put("runtimeOnly", runtime)
+        CONFIG_TO_SCOPE.put("runtimeClasspath", runtime)
+        CONFIG_TO_SCOPE.put("default", runtime)
+
+
+        /*
+         * Configurations from the Gradle Java plugin that are known to be mapped to the `provided`
+         * scope.
+         *
+         * Dependencies with the `provided` Maven scope are not propagated to dependent projects
+         * but are required during the compilation.
+         */
+        CONFIG_TO_SCOPE.put("compileOnly", provided)
+        CONFIG_TO_SCOPE.put("compileOnlyApi", provided)
+        CONFIG_TO_SCOPE.put("annotationProcessor", provided)
+    }
+
+    private DependencyWithScope(Dependency dependency, DependencyScope scope) {
+        this.dependency = dependency
+        this.scope = scope
+    }
+
+    /**
+     * Creates a new instance based on the specified dependency and its configuration.
+     *
+     * <p>The scope of the dependency is based on the name of the configuration.
+     */
+    static DependencyWithScope of(Dependency dependency, Configuration configuration) {
+        String configurationName = configuration.name
+        if (CONFIG_TO_SCOPE.containsKey(configurationName)) {
+            return new DependencyWithScope(dependency, CONFIG_TO_SCOPE.get(configurationName))
+        }
+        if (configurationName.toLowerCase().startsWith("test")) {
+            return new DependencyWithScope(dependency, DependencyScope.test)
+        }
+        return new DependencyWithScope(dependency, DependencyScope.undefined)
+    }
+
+    /**
+     * Obtains the layout priority of a scope.
+     *
+     * Layout priority determines what scopes come first in the generated {@code pom.xml} file.
+     * Dependencies with a lower priority number go on top.
+     */
+    int dependencyPriority() {
+        switch(scope) {
+            case DependencyScope.compile:
+                return 0
+            case DependencyScope.runtime:
+                return 1
+            case DependencyScope.test:
+                return 2
+            default:
+                return 3
+        }
+    }
+
+    /** Obtains the scope name of this dependency .*/
+    String scopeName() {
+        return scope.name()
+    }
+
+    /** Obtains the Gradle dependency. */
+    Dependency dependency() {
+        return this.dependency
+    }
+
+    /** Obtains the Maven scope of this dependency. */
+    DependencyScope scope() {
+        return this.scope
+    }
+
+    /**
+     * Returns {@code true} if this dependency has a defined scope, returns {@code false} otherwise.
+     */
+    boolean hasDefinedScope() { return scope != DependencyScope.undefined }
+
+    @Override
+    boolean equals(o) {
+        if (this.is(o)) return true
+        if (getClass() != o.class) return false
+
+        DependencyWithScope that = (DependencyWithScope) o
+
+        if (dependency.group != that.dependency.group) return false
+        if (dependency.name != that.dependency.name) return false
+        if (dependency.version != that.dependency.version) return false
+
+        return true
+    }
+
+    @Override
+    int hashCode() {
+        int result = (dependency != null ? dependency.hashCode() : 0)
+        return result
+    }
+
+    @Override
+    int compareTo(DependencyWithScope o) {
+        return COMPARATOR.compare(this, o)
+    }
+
+    /**
+     * A Maven dependency scope.
+     */
+    static enum DependencyScope {
+        undefined,
+        compile,
+        provided,
+        runtime,
+        test,
+        system
+        /*
+        `import` is also a scope, however, it can't be used outside the `<dependencyManagement>`
+        section, which is outside of the scope of this script
+       */
+    }
+}
+
+/**
+ * Information about the licences used by Spine in XML form.
+ */
+class SpineLicenceAsXml {
+
+    private static final String NAME = "Apache License, Version 2.0"
+    private static final String URL = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+    private static final String DISTRIBUTION = "repo"
+
+    /** Prevents instantiation. */
+    private SpineLicenceAsXml() {
+    }
+
+    /**
+     * Writes information about the Spine licence using the specified writer.
+     */
+    static void writeUsing(Writer fileWriter) {
+        MarkupBuilder xmlBuilder = new MarkupBuilder(fileWriter)
+        xmlBuilder.licenses {
+            license {
+                name(NAME)
+                url(SpineLicenceAsXml.URL)
+                distribution(DISTRIBUTION)
+            }
+        }
+    }
+}
+
+/**
+ * Information about the root project.
+ *
+ * <p>Root project is the project for which the {@code generatePom} is executed.
+ *
+ * <p>Includes group ID, artifact name and the version.
+ */
+class RootProjectData {
+
+    private final Project project
+    private final String groupId
+    private final String artifactId
+    private final String version
+
+    private RootProjectData(Project project, String group, String artifactId, String version) {
+        this.project = project
+        this.groupId = group
+        this.artifactId = artifactId
+        this.version = version
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * <p>Data from the specified project is prioritized.
+     * If a property (group ID, artifact name or version) is not found in the project,
+     * it is taken from the specified extension.
+     */
+    static RootProjectData fromEither(Project project, /* or */ ExtraPropertiesExtension extension) {
+        boolean groupMissingFromProject = project.group == null || project.group.isEmpty()
+        boolean nameMissingFromProject = project.name == null || project.name.isEmpty()
+        boolean versionMissingFromProject = project.version == null || project.version.isEmpty()
+
+        String groupId = groupMissingFromProject ? extension.groupId : project.group
+        String name = nameMissingFromProject ? extension.artifactId : project.name
+        String version = versionMissingFromProject ? extension.version : project.version
+
+        return new RootProjectData(project, groupId, name, version)
+    }
+
+    /** Obtains the project object matching the root project. */
+    Project project() {
+        return this.project
+    }
+
+    /** Obtains the group ID of the root project. */
+    String groupId() {
+        return this.groupId
+    }
+
+    /** Obtains the artifact ID of the root project. */
+    String artifactId() {
+        return this.artifactId
+    }
+
+    /** Obtains the version of the root project. */
+    String version() {
+        return this.version
+    }
+}

--- a/buildSrc/src/main/groovy/jacoco.gradle
+++ b/buildSrc/src/main/groovy/jacoco.gradle
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Apply this script to enable the combined JaCoCo test report.
+//
+// This task combines the XML report results from all Java sub-projects.
+// Inspired by: https://gist.github.com/aalmiray/e6f54aa4b3803be0bcac
+//
+// This task runs after `:check` task.
+
+import groovy.io.FileType
+
+import java.util.stream.Collectors
+
+// Required to grab dependencies for `jacocoRootReport` task.
+repositories {
+    mavenCentral()
+}
+
+// Adds the `:check` task.
+apply plugin: 'base'
+
+// Evaluate this script only after all sub-projects were evaluated.
+// Only after that it is possible to say which of the sub-projects are Java projects.
+evaluationDependsOnChildren()
+
+final def javaProjects = subprojects.findAll { it.pluginManager.hasPlugin('jacoco') }
+final def jacocoReports = file("${rootProject.buildDir}/subreports/jacoco/")
+
+task copyReports(dependsOn: javaProjects.jacocoTestReport, type: Copy) {
+    description = "Copies JaCoCo reports from subprojects into a single directory in the root project."
+
+    from files(javaProjects.jacocoTestReport.executionData)
+    into jacocoReports
+
+    rename { "${UUID.randomUUID().toString()}.exec" }
+}
+
+// Create an combined coverage report across Java modules,
+// excluding the generated content from the coverage stats.
+//
+task jacocoRootReport(dependsOn: ':copyReports', type: JacocoReport) {
+
+    final def sourceDirs = CodebaseFilter.nonGeneratedOnly(files(javaProjects.sourceSets.main.java.srcDirs))
+    additionalSourceDirs.from sourceDirs
+    sourceDirectories.from sourceDirs
+    executionData.from fileTree(jacocoReports)
+
+    final def filter = new CodebaseFilter(project,
+            javaProjects.sourceSets.main.java.srcDirs,
+            javaProjects.sourceSets.main.output)
+    final def nonGeneratedFiles = files(filter.findNonGeneratedCompiledFiles())
+    classDirectories.from nonGeneratedFiles
+    additionalClassDirs.from nonGeneratedFiles
+
+    reports {
+        html.enabled = true
+        xml.enabled = true
+        csv.enabled = false
+    }
+    onlyIf = {
+        true
+    }
+}
+
+check.dependsOn jacocoRootReport
+
+/**
+ * Serves to distinguish the {@code .java} and {@code .class} files built from
+ * the Protobuf definitions from the human-created production code.
+ */
+class CodebaseFilter {
+
+    private static final String GENERATED_PATH_MARKER = "generated"
+
+    private static final String JAVA_SRC_FOLDER_MARKER = "/java/"
+    private static final String SPINE_JAVA_SRC_FOLDER_MARKER = "main/spine/"
+    private static final String GRPC_SRC_FOLDER_MARKER = "/main/grpc/"
+
+    private static final String JAVA_OUTPUT_FOLDER_MARKER = "/main/"
+
+    private static final String JAVA_SOURCE_FILE_EXTENSION = ".java"
+    private static final String COMPILED_CLASS_FILE_EXTENSION = ".class"
+    private static final String ANONYMOUS_CLASS_MARKER = '$'
+    private static final String ANONYMOUS_CLASS_PATTERN = "\\${ANONYMOUS_CLASS_MARKER}"
+
+    private final Project project
+    private final def javaSrcDirs
+    private final def outputDirs
+
+    CodebaseFilter(final Project project, final javaSrcDirs, final outputDirs) {
+        this.project = project
+        this.javaSrcDirs = javaSrcDirs
+        this.outputDirs = outputDirs
+    }
+
+    static FileCollection nonGeneratedOnly(final FileCollection files) {
+        return files.filter {
+            !it.absolutePath.contains(GENERATED_PATH_MARKER)
+        }
+    }
+
+    static FileCollection generatedOnly(final FileCollection files) {
+        return files.filter {
+            it.absolutePath.contains(GENERATED_PATH_MARKER)
+        }
+    }
+
+    private static String parseClassName(final File file, final String sourceFolderMarker, final String extension) {
+
+        final def index = file.absolutePath.lastIndexOf(sourceFolderMarker)
+        if (index > 0) {
+            def filePathInFolder = file.absolutePath.substring(index + sourceFolderMarker.length())
+            if (filePathInFolder.endsWith(extension)) {
+                filePathInFolder = filePathInFolder.substring(0, filePathInFolder.length() - extension.length())
+
+                final def className = filePathInFolder.replace('/', '.')
+                return className
+            } else {
+                return null
+            }
+        } else {
+            return null
+        }
+    }
+
+    private LinkedList<String> getGeneratedClassNames() {
+        final def sourceFiles = project.files(javaSrcDirs)
+        final def generatedSourceFiles = generatedOnly(sourceFiles)
+
+        final def generatedClassNames = []
+        generatedSourceFiles.each { final folder ->
+            if (folder.exists() && folder.isDirectory()) {
+                folder.eachFileRecurse(FileType.FILES) { final aFile ->
+                    final def name = parseClassName(aFile, JAVA_SRC_FOLDER_MARKER, JAVA_SOURCE_FILE_EXTENSION)
+                    if (name != null) {
+                        generatedClassNames.add(name)
+                    } else {
+                        // Try another folder prefix; perhaps this file is gRPC service.
+                        final def generatedByGrpc = parseClassName(aFile,
+                                GRPC_SRC_FOLDER_MARKER,
+                                JAVA_SOURCE_FILE_EXTENSION)
+                        if (generatedByGrpc != null) {
+                            generatedClassNames.add(generatedByGrpc)
+                        } else {
+                            // Try one more folder prefix; perhaps this file is generated by Spine.
+                            final def generatedBySpine =
+                                    parseClassName(aFile, SPINE_JAVA_SRC_FOLDER_MARKER, JAVA_SOURCE_FILE_EXTENSION)
+                            if (generatedBySpine != null) {
+                                generatedClassNames.add(generatedBySpine)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return generatedClassNames
+    }
+
+    List<FileTree> findNonGeneratedCompiledFiles() {
+        log("Source dirs for code coverage calculation:")
+        final def srcDirs = project.files(javaSrcDirs)
+        srcDirs.each {
+            log(" - ${it}")
+        }
+
+        final def generatedClassNames = getGeneratedClassNames()
+        log(generatedClassNames.join('\n'))
+        final def nonGeneratedClassTree = outputDirs
+                .stream()
+                .flatMap { it.getClassesDirs().files.stream() }
+                .map { final srcFile ->
+                    log("Filtering out the generated classes for ${srcFile}")
+
+                    // Return the filtered `fileTree`s as a collected result.
+                    return project.fileTree(dir: srcFile, exclude: { final details ->
+                        def className = parseClassName(details.file, JAVA_OUTPUT_FOLDER_MARKER, COMPILED_CLASS_FILE_EXTENSION)
+
+                        // Handling anonymous classes as well.
+                        // They should be associated with the same `.java` file as their parent class.
+                        if (className != null && className.contains(ANONYMOUS_CLASS_MARKER)) {
+                            // Assuming there cannot be more than a single `$`.
+                            className = className.split(ANONYMOUS_CLASS_PATTERN)[0]
+                        }
+                        return generatedClassNames.contains(className)
+                    })
+                }.collect(Collectors.toList())
+        return nonGeneratedClassTree
+    }
+
+    private void log(final String message) {
+        project.logger.debug(message)
+    }
+}

--- a/buildSrc/src/main/groovy/javac-args.gradle
+++ b/buildSrc/src/main/groovy/javac-args.gradle
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This script configures Java Compiler.
+ */
+
+tasks.withType(JavaCompile) {
+
+    if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+        throw new GradleException("Spine Event Engine can be built with JDK 8 only." +
+                " Supporting JDK 11 and above at build-time is planned in 2.0 release." +
+                " Please use the pre-built binaries available in the Spine Maven repository." +
+                " See https://github.com/SpineEventEngine/base/issues/457.")
+    }
+
+    // Explicitly states the encoding of the source and test source files, ensuring
+    // correct execution of the `javac` task.
+    //
+    // Also promotes compiler warnings to errors, so that the build fails on warnings.
+    // This includes Error Prone warnings
+    options.encoding = 'UTF-8'
+    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+        // The last command line argument is temporarily commented out because of
+        // this issue: https://github.com/SpineEventEngine/config/issues/173
+        // Please restore when the issue is resolved.
+        //   << "-Werror"
+
+    // Configure Error Prone:
+    // 1. Exclude generated sources from being analyzed by Error Prone.
+    // 2. Turn the check off until Error Prone can handle `@Nested` JUnit classes.
+    //    See issue: https://github.com/google/error-prone/issues/956
+    // 3. Turn off checks which report unused methods and unused method parameters.
+    //    See issue: https://github.com/SpineEventEngine/config/issues/61
+    //
+    // For more config details see:
+    //    https://github.com/tbroyer/gradle-errorprone-plugin/tree/master#usage
+
+    options.errorprone.errorproneArgs.addAll('-XepExcludedPaths:.*/generated/.*',
+                                             '-Xep:ClassCanBeStatic:OFF',
+                                             '-Xep:UnusedMethod:OFF',
+                                             '-Xep:UnusedVariable:OFF',
+                                             '-Xep:CheckReturnValue:OFF',
+                                             '-Xep:FloggerSplitLogStatement:OFF')
+}

--- a/buildSrc/src/main/groovy/javadoc-options.gradle
+++ b/buildSrc/src/main/groovy/javadoc-options.gradle
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This script enables the new Javadoc tags in the build.
+ *
+ * The tags are:
+ * 1. @apiNote - the additional notes and commentaries regarding the API
+ * 2. @implSpec - the implementation specification
+ * 3. @implNote - the commentaries and notes about the implementation
+ *
+ * It also explicitly states the encoding of the source files from which the Javadoc is composed,
+ * ensuring correct execution of the `javadoc` task.
+ *
+ * For the detailed description of the new tags, see:
+ * https://blog.codefx.org/java/new-javadoc-tags/#apiNote-implSpec-and-implNote
+ *
+ * This script should be applied to the `subprojects` section of the root project,
+ * or to the specific child projects.
+ */
+
+ext {
+    javadocOptions = [
+
+            // New tags which are used in the code and titles for them.
+            "tags" : ["apiNote:a:API Note:",
+                      "implSpec:a:Implementation Requirements:",
+                      "implNote:a:Implementation Note:"],
+
+            // Encoding of the source files.
+            "encoding" : 'UTF-8'
+    ]
+}
+
+javadoc {
+    source = sourceSets.main.allJava
+    options.tags = javadocOptions.tags
+    options.encoding = javadocOptions.encoding
+}
+
+// The below config avoids numerous warnings for missing @param tags.
+// As suggested by Stephen Colebourne:
+//   https://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
+// See also:
+//   https://github.com/GPars/GPars/blob/master/build.gradle#L268
+//
+if (JavaVersion.current().isJava8Compatible()) {
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+    }
+}

--- a/buildSrc/src/main/groovy/js/build-tasks.gradle
+++ b/buildSrc/src/main/groovy/js/build-tasks.gradle
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package js
+
+/**
+ * This script declares common Gradle tasks required for JavaScript modules.
+ *
+ * <p>Most of the tasks launch a separate process which runs an NPM CLI command, so it's necessary
+ * that the NPM command line tool is installed.
+ *
+ * <p>This script doesn't configure Protobuf plugin and Spine's Protobuf JS plugin.
+ */
+
+ext {
+    JAVA_SCRIPT_TASK_GROUP = 'JavaScript'
+
+    workDirectory = "$projectDir"
+    nodeModulesDir = "$projectDir/node_modules"
+    packageJsonFile = "$projectDir/package.json"
+
+    npm = { final String... command ->
+        ext.executeNpm(workDirectory as File, command)
+    }
+}
+
+apply plugin: 'base'
+apply from: deps.scripts.npmCli
+apply from: deps.scripts.updatePackageVersion
+
+/**
+ * Compiles Protobuf sources into JavaScript.
+ *
+ * <p>This is a lifecycle task. It performs no action but triggers all the tasks which perform
+ * the compilation.
+ */
+task compileProtoToJs {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = "Compiles Protobuf sources to JavaScript."
+}
+
+/**
+ * Installs the module dependencies using the `npm install` command.
+ *
+ * The `npm install` command is executed with the vulnerability check disabled since
+ * it cannot fail the task execution despite on vulnerabilities found.
+ *
+ * To check installed Node packages for vulnerabilities execute `auditNodePackages` task.
+ */
+task installNodePackages {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Installs the module`s Node dependencies.'
+
+    inputs.file packageJsonFile
+    outputs.dir nodeModulesDir
+
+    doLast {
+        // To turn off npm audit when installing all packages. Use `auditNodePackages` task
+        // to check installed Node packages for vulnerabilities.
+        npm 'set', 'audit', 'false'
+        npm 'install'
+    }
+}
+
+/**
+ * Audits the module dependencies using the `npm audit` command.
+ *
+ * Sets the minimum level of vulnerability for `npm audit` to exit with a non-zero exit code
+ * to "high".
+ */
+task auditNodePackages {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Audits the module`s Node dependencies.'
+    dependsOn installNodePackages
+
+    inputs.dir nodeModulesDir
+
+    doLast {
+        npm 'set', 'audit-level', 'critical'
+        try {
+            npm 'audit'
+        } catch (final Exception ignored) {
+            npm 'audit', '--registry' 'http://registry.npmjs.eu'
+        }
+    }
+}
+
+check.dependsOn auditNodePackages
+
+/**
+ * Cleans output of `buildJs` and dependant tasks.
+ */
+task cleanJs {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Cleans the output of JavaScript build.'
+
+    clean.dependsOn cleanJs
+
+    doLast {
+        delete buildJs.outputs
+        delete compileProtoToJs.outputs
+        delete installNodePackages.outputs
+    }
+}
+
+/**
+ * Assembles the JS sources.
+ *
+ * This task is an analog of `build` for JS.
+ *
+ * To include a task into the JS build, depend `buildJs` onto that task.
+ */
+task buildJs {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = "Assembles the JavaScript source files."
+
+    dependsOn updatePackageVersion
+    dependsOn installNodePackages
+    dependsOn compileProtoToJs
+    assemble.dependsOn buildJs
+}
+
+/**
+ * Tests the JS sources.
+ *
+ * If `check` task is scheduled to run, this task is automatically added to
+ * the task graph and will be executed after `test` task completion.
+ */
+task testJs {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = "Tests the JavaScript source files."
+
+    dependsOn installNodePackages
+    dependsOn compileProtoToJs
+    check.dependsOn testJs
+
+    testJs.mustRunAfter test
+}
+
+idea.module {
+    excludeDirs += file(nodeModulesDir)
+}

--- a/buildSrc/src/main/groovy/js/configure-proto.gradle
+++ b/buildSrc/src/main/groovy/js/configure-proto.gradle
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package js
+
+import io.spine.internal.dependency.Protobuf
+import io.spine.internal.gradle.Scripts
+
+/**
+ * Configures how the Proto definitions of the project are compiled into JavaScript and their
+ * publishing.
+ *
+ * Use this script if the project contains Proto files that should be published as a separate NPM
+ * module.
+ *
+ * The prerequisites for using the script are:
+ *
+ * 1. The Spine Proto JS plugin applied to the project
+ * (see https://github.com/SpineEventEngine/base/tree/master/tools/mc-js).
+ *
+ * 2. The extension variable `versionToPublishJs` configured to represent the version under which
+ * the NPM packages should be published.
+ */
+
+ext {
+    genProtoBaseDir = "$projectDir/generated"
+    genProtoMain = "$genProtoBaseDir/main/js"
+    genProtoTest = "$genProtoBaseDir/test/js"
+}
+
+apply from: Scripts.npmPublishTasks
+
+/**
+ * Configures the JS code generation.
+ */
+protobuf {
+    generatedFilesBaseDir = genProtoBaseDir
+    protoc {
+        artifact = Protobuf.protoc
+    }
+    generateProtoTasks {
+        all().each { final task ->
+            task.builtins {
+                // For information on JavaScript code generation please see
+                // https://github.com/google/protobuf/blob/master/js/README.md
+                js {
+                    option "import_style=commonjs"
+                }
+
+                task.generateDescriptorSet = true
+                final def testClassifier = task.sourceSet.name == "test" ? "_test" : ""
+                final def descriptorName =
+                        "${project.group}_${project.name}_${project.version}${testClassifier}.desc"
+                task.descriptorSetOptions.path =
+                        "${projectDir}/build/descriptors/${task.sourceSet.name}/${descriptorName}"
+            }
+            compileProtoToJs.dependsOn task
+        }
+    }
+}
+
+/**
+ * Configures the generation of additional features for the Proto messages via Spine Proto JS
+ * plugin.
+ */
+protoJs {
+    mainGenProtoDir = genProtoMain
+    testGenProtoDir = genProtoTest
+
+    generateParsersTask().dependsOn compileProtoToJs
+    buildJs.dependsOn generateParsersTask()
+}
+
+/**
+ * Prepares Proto files for publication, see {@code npm-publish-tasks.gradle}.
+ */
+prepareJsPublication {
+
+    doLast {
+        copy {
+            from (projectDir) {
+                include 'package.json'
+                include '.npmrc'
+            }
+
+            from (genProtoMain) {
+                include '**'
+            }
+
+            into publicationDirectory
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/js/npm-cli.gradle
+++ b/buildSrc/src/main/groovy/js/npm-cli.gradle
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package js
+
+import org.apache.tools.ant.taskdefs.condition.Os
+
+/**
+ * The script allowing to run NPM commands from Gradle.
+ */
+
+
+/**
+ * The name of an environmental variable which contains the NPM auth token.
+ *
+ * <p>The token is used for publishing only.
+ *
+ * <p>It is required to set this variable before invoking NPM commands.
+ */
+ext.NPM_TOKEN_VARIABLE = "NPM_TOKEN"
+
+/**
+ * @return the value of `NPM_TOKEN` environmental variable or a stub value, if the token is not set
+ */
+String npmToken() {
+    final def tokenVarValue = System.getenv(NPM_TOKEN_VARIABLE)
+    final def token = tokenVarValue?.isEmpty() ? "PUBLISHING_FORBIDDEN" : tokenVarValue
+    return token
+}
+
+/**
+ * Executes the given command depending on the current OS.
+ *
+ * @param workingDirArg  the directory to execute the command in
+ * @param windowsCommand the command to execute is the OS is Windows
+ * @param unixCommand    the command to execute is the OS is Unix-like
+ * @param params         the command params, platform-independent
+ */
+def execMultiplatform(final File workingDirArg,
+                      final String windowsCommand,
+                      final String unixCommand,
+                      final String[] params) {
+    exec {
+        final String command = Os.isFamily(Os.FAMILY_WINDOWS) ? windowsCommand : unixCommand
+        final List resultingParams = [command] + Arrays.asList(params)
+        workingDir = workingDirArg
+        commandLine = resultingParams
+        environment NPM_TOKEN_VARIABLE, npmToken()
+    }
+}
+
+def runNpm(final File launchDir, final String[] params) {
+    execMultiplatform launchDir, 'npm.cmd', 'npm', params
+}
+
+ext {
+
+    /**
+     * Executes an {@code npm} CLI command.
+     *
+     * For example, to execute command {@code npm run compile}, invoke this function as follows:
+     * {@code executeNpm 'run', 'compile'}
+     *
+     * @param params the command parameters
+     */
+    executeNpm = { final File from = projectDir, final String... params ->
+        runNpm(from, params)
+    }
+}

--- a/buildSrc/src/main/groovy/js/npm-publish-tasks.gradle
+++ b/buildSrc/src/main/groovy/js/npm-publish-tasks.gradle
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package js
+
+/**
+ * The script declares tasks for publishing to NPM.
+ *
+ * <p>In order to publish the NPM module, it is required that the {@code NPM_TOKEN} environment
+ * variable is set to a valid NPM auth token. If the token is not set, a dummy value is added to
+ * the NPM execution process, which is sufficient for the local development.
+ */
+
+apply from: deps.scripts.jsBuildTasks
+
+ext {
+    publicationDirectory = "$buildDir/npm-publication/"
+}
+
+/**
+ * A task to prepare files for publication.
+ *
+ * <p>Does nothing by default, so a user should configure this task
+ * to copy all required files to the {@code publicationDirectory}.
+ * 
+ * <p>The task is performed before {@code link} and {@code publishJs} tasks.
+ * 
+ * <p>The task isn't a {@code copy} task since it causes side effects
+ * like a removal of the publication directory. See https://github.com/gradle/gradle/issues/1012.
+ */
+task prepareJsPublication {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Prepares the NPM package for publish.'
+
+    dependsOn buildJs
+}
+
+/**
+ * Publishes the NPM package locally with `npm link`.
+ */
+task link {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = "Publishes the NPM package locally."
+
+    doLast {
+        executeNpm(publicationDirectory as File, 'link')
+    }
+
+    dependsOn prepareJsPublication
+}
+
+/**
+ * Publishes the NPM package with `npm publish`.
+ */
+task publishJs {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Publishes the NPM package.'
+
+    doLast {
+        executeNpm(publicationDirectory as File, 'publish')
+    }
+
+    dependsOn prepareJsPublication
+    publish.dependsOn publishJs
+}

--- a/buildSrc/src/main/groovy/js/update-package-version.gradle
+++ b/buildSrc/src/main/groovy/js/update-package-version.gradle
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package js
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
+/**
+ * This script declares a task to update the version in in a package.json file.
+ */
+
+/**
+ * Updates the package.json version to the specified one.
+ * 
+ * <p>The path of the package.json and the version to set has default values,
+ * but can be redefined:
+ * 
+ * <pre>{@code
+ * updatePackageVersion.packageJsonPath = "custom/package.json"
+ * updatePackageVersion.newVersion = npmPackageVersion
+ * }</pre>
+ */
+task updatePackageVersion() {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Updates the version in package.json.'
+    
+    ext.packageJsonPath = packageJsonFile
+    ext.newVersion = versionToPublishJs
+
+    doLast {
+        updatePackageJsonVersion(packageJsonPath as String, newVersion as String)
+    }
+}
+
+void updatePackageJsonVersion(final String packageJsonPath, final String newVersion) {
+    def final packageJsonObject = readJsonFile(packageJsonPath)
+
+    packageJsonObject['version'] = newVersion
+    updatePackageJson(packageJsonObject, packageJsonPath)
+}
+
+Object readJsonFile(final String sourcePath) {
+    def final packageJsonFile = file(sourcePath)
+    return new JsonSlurper().parseText(packageJsonFile.text)
+}
+
+static void updatePackageJson(final jsonObject, final String destinationPath) {
+    def final updatedText = JsonOutput.toJson(jsonObject)
+    def final prettyText = prettify(updatedText)
+    new File(destinationPath).text = prettyText
+}
+
+static String prettify(final String jsonText) {
+    def prettyText = JsonOutput.prettyPrint(jsonText)
+    prettyText = prettyText.replace('  ', ' ')
+    prettyText = prettyText.replaceAll(/\{\s+}/, '{}')
+    prettyText = prettyText + '\n'
+    return prettyText
+}

--- a/buildSrc/src/main/groovy/license-report-common.gradle
+++ b/buildSrc/src/main/groovy/license-report-common.gradle
@@ -24,44 +24,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+/**
+ * This script defines the common configuration for license report scripts.
+ */
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+apply plugin: 'base'
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
+ext.licenseReportConfig = [
+        // The output filename
+        outputFilename  : "license-report.md",
 
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
-}
+        // The path to a directory, to which a per-project report is generated.
+        relativePath    : "/reports/dependency-license/dependency"
+]

--- a/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/buildSrc/src/main/groovy/license-report-project.gradle
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+//file:noinspection UnnecessaryQualifiedReference
+
+import com.github.jk1.license.*
+import com.github.jk1.license.render.ReportRenderer
+
+/**
+ * This script plugin generates the license report for all dependencies used in a project.
+ *
+ * <p>Transitive dependencies are included.
+ *
+ * <p>Use `generateLicenseReport` task to trigger the generation.
+ */
+
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    dependencies {
+        classpath io.spine.internal.dependency.LicenseReport.lib
+    }
+}
+
+apply plugin: io.spine.internal.dependency.LicenseReport.GradlePlugin.id
+
+final def commonPath = io.spine.internal.gradle.Scripts.commonPath
+apply from: "${rootDir}/${commonPath}/license-report-common.gradle"
+
+final reportOutputDir = "${project.buildDir}" + licenseReportConfig.relativePath
+licenseReport {
+    outputDir = "$reportOutputDir"
+    excludeGroups = ['io.spine', 'io.spine.tools', 'io.spine.gcloud']
+    configurations = ALL
+    renderers = [new MarkdownReportRenderer(licenseReportConfig.outputFilename)]
+}
+
+/**
+ * Renders the dependency report in markdown.
+ */
+class MarkdownReportRenderer implements ReportRenderer {
+
+    private Project project
+    private LicenseReportExtension config
+    private File output
+    private String fileName
+
+    MarkdownReportRenderer(final String fileName) {
+        this.fileName = fileName
+    }
+
+    @Input
+    private String getFileNameCache() { return this.fileName }
+
+    void render(final ProjectData data) {
+        project = data.project
+        config = project.licenseReport
+        output = new File(config.outputDir, fileName)
+        output.text = """
+    \n# Dependencies of `$project.group:spine-$project.name:$project.version`
+"""
+        printDependencies(data)
+        output << """
+    
+        \n The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
+"""
+        output << "\n\nThis report was generated on **${new Date()}**"
+        output << " using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE)."
+    }
+
+    private void printDependencies(final ProjectData data) {
+
+        final runtimeDependencies = new HashSet()
+        final compileToolingDependencies = new HashSet()
+
+        data.configurations.each { final ConfigurationData config ->
+
+
+            if(["runtime", "runtimeClasspath"].indexOf(config.name) != -1) {
+                runtimeDependencies.addAll(config.dependencies)
+            } else {
+                compileToolingDependencies.addAll(config.dependencies)
+            }
+        }
+
+        output << "\n## Runtime"
+        runtimeDependencies.toArray().sort().each {
+            printModuleDependency(it)
+        }
+
+        output << "\n## Compile, tests and tooling"
+        compileToolingDependencies.toArray().sort().each {
+            printModuleDependency(it)
+        }
+    }
+
+    private void printModuleDependency(final ModuleData data) {
+        boolean projectUrlDone = false
+        output << "\n1."
+
+        if (data.group) {
+            output << " **Group:** $data.group"
+        }
+        if (data.name) {
+            output << " **Name:** $data.name"
+        }
+        if (data.version) {
+            output << " **Version:** $data.version"
+        }
+        if (data.poms.isEmpty() && data.manifests.isEmpty()) {
+            output << " **No license information found**"
+            return
+        }
+
+        if (!data.manifests.isEmpty() && !data.poms.isEmpty()) {
+            final ManifestData manifest = data.manifests.first()
+            final PomData pomData = data.poms.first()
+            if (manifest.url && pomData.projectUrl && manifest.url == pomData.projectUrl) {
+                output << "\n     * **Project URL:** [$manifest.url]($manifest.url)"
+                projectUrlDone = true
+            }
+        }
+
+        if (!data.manifests.isEmpty()) {
+            final ManifestData manifest = data.manifests.first()
+            if (manifest.url && !projectUrlDone) {
+                output << "\n     * **Manifest Project URL:** [$manifest.url]($manifest.url)"
+            }
+            if (manifest.license) {
+                if (manifest.license.startsWith("http")) {
+                    output << "\n     * **Manifest license URL:** [$manifest.license]($manifest.license)"
+
+                } else if (manifest.hasPackagedLicense) {
+                    output << "\n     * **Packaged License File:** [$manifest.license]($manifest.url)"
+                } else {
+                    output << "\n     * **Manifest License:** $manifest.license (Not packaged)"
+
+                }
+            }
+        }
+
+        if (!data.poms.isEmpty()) {
+            final PomData pomData = data.poms.first()
+            if (pomData.projectUrl && !projectUrlDone) {
+                output << "\n     * **POM Project URL:** [$pomData.projectUrl]($pomData.projectUrl)"
+
+            }
+            if (pomData.licenses) {
+                pomData.licenses.each { final License license ->
+                    output << "\n     * **POM License: $license.name**"
+
+                    if (license.url) {
+                        if (license.url.startsWith("http")) {
+                            output << " - [$license.url]($license.url)"
+                        } else {
+                            output << " **License:** $license.url"
+
+                        }
+                    }
+                }
+            }
+        }
+        output << '\n'
+    }
+}

--- a/buildSrc/src/main/groovy/license-report-repo.gradle
+++ b/buildSrc/src/main/groovy/license-report-repo.gradle
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This script launches the per-project license report generation, concatenates the results
+ * and puts the resulting file into a repository root folder.
+ *
+ * The script also configures the `build` task to be finalized by the license report routines.
+ *
+ * See `license-report-project.gradle` for a per-project license report generation.
+ */
+
+final def commonPath = io.spine.internal.gradle.Scripts.commonPath
+apply from: "${rootDir}/${commonPath}/license-report-common.gradle"
+
+task reportLicensesInRepo { final Task task ->
+    subprojects.each {
+        subprojects.each {
+            final def generateLicenseReport = it.tasks.findByName('generateLicenseReport')
+            task.dependsOn(generateLicenseReport)
+            generateLicenseReport.dependsOn(it.tasks.findByName('assemble'))
+        }
+    }
+
+    doLast {
+        final paths = subprojects.collect {
+            "${it.buildDir}${licenseReportConfig.relativePath}/${licenseReportConfig.outputFilename}"
+        }
+
+        println "Aggregating the reports from the subprojects."
+        final aggregatedContent = paths.collect { (new File(it)).getText() }.join("\n\n\n")
+
+        (new File("$rootDir/$licenseReportConfig.outputFilename")).text = aggregatedContent
+    }
+}
+
+build.finalizedBy reportLicensesInRepo
+reportLicensesInRepo.dependsOn assemble

--- a/buildSrc/src/main/groovy/model-compiler.gradle
+++ b/buildSrc/src/main/groovy/model-compiler.gradle
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This script configures Spine defaults for the Model Compiler code generation.
+ *
+ * Applies the following interfaces generation configurations:
+ * — all messages in Protobuf files ending with "commands.proto" are marked as `CommandMessage`;
+ * — all messages in Protobuf files ending with "events.proto" are marked as `EventMessage`;
+ * — all messages in Protobuf files ending with "rejections.proto" are marked as `RejectionMessage`;
+ * — all messages that qualify to be UUID messages are marked as `UuidValue`;
+ * — all messages that represent an entity state are marked as `EntityState`.
+ *
+ * And the following method generations are applied:
+ * — all messages that qualify to be UUID messages have helper `generate` and `of` methods
+ *   generated using `UuidMethodFactory`;
+ *
+ * The generation of messages representing an entity state are appended with
+ * - entity columns for the fields marked as `column`;
+ * - entity query and entity query builder DSL.
+ *
+ * The fields of the messages are marked with certain interfaces:
+ * - `io.spine.base.EventMessageField` set to those in `*events.proto` and `*rejections.proto`;
+ * - `io.spine.query.EntityStateField` set to the fields of messages representing an entity state.
+ *
+ *
+ * Be aware that the root project `buildscript` should already have a classpath
+ * `io.spine.tools:spine-mc-java:<version>` classpath dependency.
+ */
+
+modelCompiler {
+
+    interfaces {
+        mark messages().inFiles(suffix: "commands.proto"), asType("io.spine.base.CommandMessage")
+        mark messages().inFiles(suffix: "events.proto"), asType("io.spine.base.EventMessage")
+        mark messages().inFiles(suffix: "rejections.proto"), asType("io.spine.base.RejectionMessage")
+        mark messages().uuid(), asType("io.spine.base.UuidValue")
+        mark messages().entityState(), asType("io.spine.base.EntityState")
+    }
+
+    methods {
+        applyFactory "io.spine.tools.java.code.UuidMethodFactory", messages().uuid()
+    }
+
+    entityQueries {
+        generate = true
+    }
+
+    fields {
+        generateFor messages().inFiles(suffix: "events.proto"), markAs("io.spine.base.EventMessageField")
+        generateFor messages().inFiles(suffix: "rejections.proto"), markAs("io.spine.base.EventMessageField")
+        generateFor messages().entityState(), markAs("io.spine.query.EntityStateField")
+    }
+}

--- a/buildSrc/src/main/groovy/pmd.gradle
+++ b/buildSrc/src/main/groovy/pmd.gradle
@@ -24,44 +24,29 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
+/*
+ * This script configures Gradle PMD plugin.
+ */
+pmd {
+    toolVersion = "${io.spine.internal.dependency.Pmd.version}"
+    consoleOutput = true
+    incrementalAnalysis = true
+
+    // The build is going to fail in case of violations.
+    ignoreFailures = false
+
+    // Disable the default rule set to use the custom rules (see below).
+    ruleSets = []
+
+    // A set of custom rules.
+    ruleSetFiles = files("$rootDir/config/quality/pmd.xml")
+
+    reportsDir = file("build/reports/pmd")
+
+    // Just analyze the main sources; do not analyze tests.
+    sourceSets = [sourceSets.main]
 }
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
-}
+// Workaround for https://github.com/pmd/pmd/issues/1705.
+pmdMain.classpath += sourceSets.main.runtimeClasspath

--- a/buildSrc/src/main/groovy/publish-proto.gradle
+++ b/buildSrc/src/main/groovy/publish-proto.gradle
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This plugin enables a project to publish a JAR containing all the {@code .proto} definitions
+ * found in the project classpath, which is the definitions from {@code sourceSets.main.proto} and
+ * the proto files extracted from the JAR dependencies of the project.
+ *
+ * <p>The relative file paths are kept.
+ *
+ * <p>To depend onto such artifact of e.g. the spine-client module, use:
+ * <pre>
+ *     {@code
+ *     dependencies {
+ *         compile "io.spine:spine-client:$version@proto"
+ *     }
+ *     }
+ * </pre>
+ *
+ * <p>To enable the artifact publishing for a project, apply this plugin to it:
+ * <pre>
+ *     {@code
+ *     apply from: "$rootDir/config/gradle/publish-proto.gradle"
+ *     }
+ * </pre>
+ */
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+
+    dependencies {
+        //noinspection UnnecessaryQualifiedReference
+        classpath io.spine.internal.dependency.Guava.lib
+    }
+}
+
+task assembleProto(type: Jar) {
+    description "Assembles a JAR artifact with all Proto definitions from the classpath."
+    from { collectProto() }
+    include { isProtoFileOrDir(it.file) }
+    classifier 'proto'
+}
+
+artifacts {
+    archives assembleProto
+}
+
+/**
+ * Collects all the directories from current project and its dependencies (including zip tree
+ * directories) which contain {@code .proto} definitions.
+ *
+ * <p>The directories may in practice include files of other extension. The caller should take care
+ * of handling those files respectively.
+ *
+ * <p>It's guaranteed that there are no other Proto definitions in the current project classpath
+ * except those included into the returned {@code Collection}.
+ */
+Collection<File> collectProto() {
+    final def dependencies = configurations.compile.files
+    final def jarFiles = dependencies.collect { JarFileName.ofFile(it) }
+    final def result = new HashSet<>()
+    for (final File jarFile in dependencies) {
+        if (jarFile.name.endsWith(".jar")) {
+            final def zipTree = zipTree(jarFile)
+            try {
+                for (final File file in zipTree) {
+                    if (isProtoFile(file)) {
+                        result.add(getProtoRoot(file, jarFiles))
+                    }
+                }
+            } catch (GradleException e) {
+                /*
+                 * As the :assembleProto task configuration is resolved first upon the project
+                 * configuration (and we don't have the dependencies there yet) and then upon
+                 * the execution, the task should complete successfully.
+                 *
+                 * To make sure the configuration phase passes, we suppress the GradleException
+                 * thrown by `zipTree()` indicating that the given file, which is a dependency JAR
+                 * file does not exist.
+                 *
+                 * Though, if this error is thrown on the execution phase, this IS an error. Thus,
+                 * we log an error message.
+                 *
+                 * As a side effect, the message is shown upon `./gradlew clean build` or upon
+                 * a newly created version of framework build etc.
+                 */
+                logger.debug(
+                        "${e.message}${System.lineSeparator()}The proto artifact may be corrupted."
+                )
+            }
+        }
+    }
+    result.addAll(sourceSets.main.proto.srcDirs)
+    return result
+}
+
+/**
+ * Returns the root directory containing a Proto package.
+ *
+ * @param member the member File of the Proto package
+ * @param jarNames the full listing of the project JAR dependencies
+ */
+static File getProtoRoot(final File member, final Collection<JarFileName> jarNames) {
+    File pkg = member
+    while (!jarNames.contains(jarName(pkg.parentFile))) {
+        pkg = pkg.parentFile
+    }
+    return pkg.parentFile
+}
+
+/**
+ * Retrieves the name of the given folder trimmed by {@code ".jar"} suffix.
+ *
+ * <p>More formally, returns the name of the given {@link File} if the name does not contain
+ * {@code ".jar"} substring or the substring of the name containing the characters from the start
+ * to the {@code ".jar"} sequence (inclusively).
+ *
+ * <p>This transformation corresponds to finding the name of a JAR file which was extracted to
+ * the given directory with Gradle {@code zipTree()} API.
+ *
+ * @param jar the folder to get the JAR name for
+ */
+static JarFileName jarName(final File jar) {
+    final String unpackedJarInfix = ".jar"
+    final String name = jar.name
+    final int index = name.lastIndexOf(unpackedJarInfix)
+    if (index < 0) {
+        return null
+    } else {
+        return JarFileName.ofValue(name.substring(0, index + unpackedJarInfix.length()))
+    }
+}
+
+/**
+ * Checks if the given abstract pathname represents either a {@code .proto} file, or a directory
+ * containing proto files.
+ *
+ * <p>If {@code candidate} is a directory, scans its children recursively.
+ *
+ * @param candidate the {@link File} to check
+ * @return {@code true} if the {@code candidate} {@linkplain #isProtoFile is a Protobuf file} or
+ *         a directory containing at least one Protobuf file
+ */
+static boolean isProtoFileOrDir(final File candidate) {
+    final Deque<File> filesToCheck = new LinkedList<>()
+    filesToCheck.push(candidate)
+    if (candidate.isDirectory() && candidate.list().length == 0) {
+        return false
+    }
+    while (!filesToCheck.isEmpty()) {
+        final File file = filesToCheck.pop()
+        if (isProtoFile(file)) {
+            return true
+        }
+        if (file.isDirectory()) {
+            file.listFiles().each { filesToCheck.push(it) }
+        }
+    }
+    return false
+}
+
+/**
+ * Checks if the given file is a {@code .proto} file.
+ *
+ * @param file the file to check
+ * @return {@code true} if the {@code file} is a Protobuf file, {@code false} otherwise
+ */
+static boolean isProtoFile(final File file) {
+    return file.isFile() && file.name.endsWith(".proto")
+}
+
+/**
+ * The filename of a JAR dependency of the project.
+ */
+final class JarFileName {
+
+    final String value
+
+    private JarFileName(final String value) {
+        this.value = value
+    }
+
+    static JarFileName ofFile(final File jar) {
+        return new JarFileName(jar.name)
+    }
+
+    static JarFileName ofValue(final String value) {
+        return new JarFileName(value)
+    }
+
+    boolean equals(final o) {
+        if (this.is(o)) return true
+        if (getClass() != o.class) return false
+
+        final JarFileName that = (JarFileName) o
+
+        if (value != that.value) return false
+
+        return true
+    }
+
+    int hashCode() {
+        return (value != null ? value.hashCode() : 0)
+    }
+}

--- a/buildSrc/src/main/groovy/publish.gradle
+++ b/buildSrc/src/main/groovy/publish.gradle
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+  Apply this script to add ability to publish the needed artifacts.
+
+  To publish more artifacts for a certain project, add them to the archives configuration:
+  ```
+  artifacts {
+      archives myCustomJarTask
+  }
+  ```
+ */
+
+println("`publish.gradle` script is deprecated. Please use the `Publish` plugin instead.")
+
+task publish {
+    doLast {
+        // Keep the task for dynamic generation while publishing.
+    }
+}
+
+void dependPublish(final project) {
+    final credentialsTasks = getTasksByName("readPublishingCredentials", false)
+    project.getTasksByName("publish", false).each { final task ->
+        task.dependsOn credentialsTasks
+    }
+    publish.dependsOn project.getTasksByName("publish", false)
+}
+
+projectsToPublish.each {
+    project(":$it") { final currentProject ->
+        apply plugin: 'maven-publish'
+
+        logger.debug("Applying `maven-publish` plugin to ${currentProject.name}.")
+
+        currentProject.artifacts {
+            archives sourceJar
+            archives testOutputJar
+            archives javadocJar
+        }
+
+        final propertyName = "spinePrefix"
+        final ext = rootProject.ext
+        final boolean spinePrefix =  ext.has(propertyName) ? ext.get(propertyName) : true
+
+        // Artifact IDs are composed as "spine-<project.name>". Example:
+        //
+        //      "spine-mc-java"
+        //
+        // That helps to distinguish resulting JARs in the final assembly, such as WAR package.
+        //
+        final String artifactIdForPublishing =
+                spinePrefix ?
+                        "spine-${currentProject.name}" :
+                        currentProject.name
+
+        final def publishingAction = {
+            currentProject.publishing {
+                publications {
+                    mavenJava(MavenPublication) {
+                        groupId = "${currentProject.group}"
+                        artifactId = "${artifactIdForPublishing}"
+                        version = "${currentProject.version}"
+
+                        from components.java
+
+                        artifacts = configurations.archives.allArtifacts
+                    }
+                }
+            }
+        }
+        if (currentProject.state.executed) {
+            publishingAction()
+        } else {
+            currentProject.afterEvaluate(publishingAction)
+        }
+
+        final boolean isSnapshots = currentProject.version.matches('.+[-\\.]SNAPSHOT([\\+\\.]\\d+)?')
+
+        publishing {
+            repositories {
+                maven {
+                    final String publicRepo = (isSnapshots
+                            ? publishToRepository.snapshots
+                            : publishToRepository.releases
+                    )
+
+                    // Special treatment for CloudRepo URL.
+                    // Reading is performed via public repositories, and publishing via private
+                    // ones that differ in the `/public` infix.
+                    final urlToPublish = publicRepo.replace("/public", "")
+
+                    // Assign URL to the plugin property.
+                    url = urlToPublish
+
+                    final creds = rootProject.publishToRepository.credentials(project)
+
+                    credentials {
+                        username = creds.username
+                        password = creds.password
+                    }
+                }
+            }
+        }
+
+        dependPublish(project)
+    }
+}

--- a/buildSrc/src/main/groovy/run-build.gradle
+++ b/buildSrc/src/main/groovy/run-build.gradle
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Apply this script if it is needed to execute {@code ./gradlew clean build} task
+ * from another project.
+ */
+
+configure(project.rootProject) {
+
+    ext {
+
+        /**
+         * Executes {@code ./gradlew clean build} command, if there is a {@code 'clean'} task.
+         * Otherwise, executes {@code ./gradlew build}.  
+         * 
+         * @param directory the project root directory in which to execute the build
+         */
+        runBuild = { final GString directory ->
+            final boolean shouldClean = gradle.getTaskGraph().hasTask(':clean')
+            final def command = []
+            final def runsOnWindows = org.gradle.internal.os.OperatingSystem.current().isWindows()
+            final def script = runsOnWindows ? "gradlew.bat" : "gradlew"
+            command.add("$rootDir/$script".toString())
+            if (shouldClean) {
+                command.add('clean')
+            }
+            command.add('build')
+            command.add('--console=plain')
+            command.add('--debug')
+            command.add('--stacktrace')
+
+            // Ensure build error output log.
+            // Since we're executing this task in another process, we redirect error output to
+            // the file under the `build` directory.
+            final File buildDir = new File(directory, "build")
+            if (!buildDir.exists()) {
+                buildDir.mkdir()
+            }
+            final File errorOut = new File(buildDir, 'error-out.txt')
+            final File debugOut = new File(buildDir, 'debug-out.txt')
+
+            final def process = new ProcessBuilder()
+                    .command(command)
+                    .directory(file(directory))
+                    .redirectError(errorOut)
+                    .redirectOutput(debugOut)
+                    .start()
+            if (process.waitFor() != 0) {
+                throw new GradleException("Build FAILED. See $errorOut for details.")
+            }
+        }
+    }
+}
+

--- a/buildSrc/src/main/groovy/slow-tests.gradle
+++ b/buildSrc/src/main/groovy/slow-tests.gradle
@@ -24,44 +24,23 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+final def slowTag = 'slow' // See io.spine.testing.SlowTest
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+task fastTest(type: Test) {
+    description = 'Executes all JUnit tests but the ones tagged as "slow".'
+    group = 'Verification'
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
+    useJUnitPlatform {
+        excludeTags slowTag
     }
+}
+
+task slowTest(type: Test) {
+    description = 'Executes JUnit tests tagged as "slow".'
+    group = 'Verification'
+
+    useJUnitPlatform {
+        includeTags slowTag
+    }
+    shouldRunAfter fastTest
 }

--- a/buildSrc/src/main/groovy/test-artifacts.gradle
+++ b/buildSrc/src/main/groovy/test-artifacts.gradle
@@ -24,44 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
-
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
+// Apply this script if it is needed to use test classes of the current project in other projects.
+// The dependency looks like this:
+//
+// testCompile project(path: ":projectWithTests", configuration: 'testArtifacts')
+//
+configurations {
+    testArtifacts.extendsFrom testRuntime
 }
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
+task testJar(type: Jar) {
+    classifier "test"
+    from sourceSets.test.output
 }
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+artifacts {
+    testArtifacts testJar
 }

--- a/buildSrc/src/main/groovy/test-output.gradle
+++ b/buildSrc/src/main/groovy/test-output.gradle
@@ -24,44 +24,37 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+/*
+ * This plugin configured the test output as follows:
+ *
+ *  - the standard streams of the tests execution are logged;
+ *  - exceptions thrown in tests are logged;
+ *  - after all the tests are executed, a short test summary is logged; the summary shown the number
+ *    of tests and their results.
+ */
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+tasks.withType(Test).each {
+    it.testLogging {
+        showStandardStreams = true
+        showExceptions = true
+        showStackTraces = true
+        showCauses = true
+        exceptionFormat = 'full'
+    }
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
+    it.afterSuite { final testDescriptor, final result ->
+        // If the descriptor has no parent, then it is the root test suite, i.e. it includes the
+        // info about all the run tests.
+        if (!testDescriptor.parent) {
+            logger.lifecycle(
+                    """
+                    Test summary:
+                    >> ${result.testCount} tests
+                    >> ${result.successfulTestCount} succeeded
+                    >> ${result.failedTestCount} failed
+                    >> ${result.skippedTestCount} skipped
+                    """
+            )
         }
     }
 }

--- a/buildSrc/src/main/groovy/update-gh-pages.gradle
+++ b/buildSrc/src/main/groovy/update-gh-pages.gradle
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This script publishes the generated documentation to the `spine.io` site via GitHub pages by
+ * pushing commits to the `gh-pages` branch.
+ *
+ * To configure docs publishing, apply this script to the repositories which should generate
+ * the doc:
+ * ```
+ * apply(from: io.spine.gradle.internal.Scripts.updateGitHubPages)
+ * ```
+ * After that, the `updateGitHubPages` task will be available for that project.
+ *
+ * By default, the non-internal Javadoc is included into the publication. It is possible to publish
+ * all the Javadoc regardless of API status by setting the value of the `allowInternalJavadoc`
+ * extension property to `true`. If needed, the publication may be extended to include other files.
+ * To do so, append more files/file collections to the `generatedDocs` extension property.
+ *
+ * In order to work, the script needs a `deploy_key_rsa` private RSA key file in the repository
+ * root. It is recommended to decrypt it in the repository an then decrypt it on CI upon
+ * a publication. Also, the script uses the `FORMAL_GIT_HUB_PAGES_AUTHOR` environmental variable to
+ * set the author email for the commits. The `gh-pages` branch itself should exist before the script
+ * is run.
+ */
+
+import java.nio.file.Files
+
+ext {
+    javadocDir = Files.createTempDirectory("javadoc")
+    generatedDocs = files(javadocDir)
+    repositoryTempDir = Files.createTempDirectory("repoTemp")
+}
+
+final String propertyName = 'allowInternalJavadoc'
+
+final boolean allowInternalJavadoc = ext.has(propertyName) && ext.get(propertyName)
+
+if (!allowInternalJavadoc) {
+    final def commonPath = io.spine.internal.gradle.Scripts.commonPath
+    apply from: "${rootDir}/${commonPath}/filter-internal-javadoc.gradle"
+}
+
+/**
+ * Copies the Javadoc produced by a Javadoc task into a temporary folder.
+ *
+ * If `@Internal` Javadoc is allowed, uses the `:javadoc` task. Otherwise, uses
+ * the `:noInternalJavadoc` task.
+ *
+ * To allow `@Internal` Javadoc, set `ext.allowInternalJavadoc` property to `true` before applying
+ * this script to the project.
+ */
+task copyJavadoc(type: Copy) {
+    from allowInternalJavadoc ? tasks['javadoc'] : tasks['noInternalJavadoc']
+    into javadocDir
+}
+
+/**
+ * Updates the Javadoc documentation on the {@code gh-pages} Git branch.
+ *
+ * <p>Run this task when it is required to update the Javadoc e.g. when merging a branch into
+ * {@code master}.
+ */
+task updateGitHubPages {
+    description "Updates the Javadoc published to GitHub Pages website."
+    dependsOn copyJavadoc
+}
+
+/**
+ * Waits for the given {@code process} to finish and retrieves the result of execution.
+ *
+ * @param process the process to execute
+ * @return a tuple of format: [exitCode:<Process exit code integer>,
+ *                             out: <Process stdout output as a String>,
+ *                             error: <Process stderr output as a String>]
+ */
+static def executeForResult(final Process process) {
+    final def outWriter = new StringWriter()
+    final def errWriter = new StringWriter()
+    process.consumeProcessOutputStream(outWriter)
+    process.consumeProcessErrorStream(errWriter)
+    final int exitCode = process.waitFor()
+    final def result = [out: outWriter.toString(), error: errWriter.toString(), exitCode: exitCode]
+    return result
+}
+
+/**
+ * Executes the given terminal command and retrieves the command output.
+ *
+ * <p>{@link Runtime#exec(String[], String[], File) Executes} the given {@code String} array as
+ * a CLI command. If the execution is successful, returns the command output. Throws
+ * an {@link IllegalStateException} otherwise.
+ *
+ * @param baseDir the directory of the command execution
+ * @param command the command to execute
+ * @return the command line output
+ * @throws IllegalStateException upon an execution error
+ */
+static String execute(final File baseDir, final String... command) {
+    final Runtime runtime = Runtime.getRuntime()
+    final Process proc = runtime.exec(command, /*env=*/ (String[]) null, baseDir)
+    final def result = executeForResult(proc)
+    if (result.exitCode == 0) {
+        return result.out
+    } else {
+        final String errorMsg = "Command `$command` finished with exit code $result.exitCode:" +
+                " ${System.lineSeparator()}${result.error}" +
+                " ${System.lineSeparator()}${result.out}"
+        throw new IllegalStateException(errorMsg)
+    }
+}
+
+/**
+ * Executes the given CLI command and retrieves the command output.
+ *
+ * <p>This is a convenience method. Calling this method is equivalent to calling
+ * {@code execute(project.rootDir, command)}.
+ */
+String execute(final String... command) {
+    return execute(rootDir, command)
+}
+
+/**
+ * The GitHub deploy key used to push the doc changes to the {@code gh-pages} branch.
+ */
+final File gitHubAccessKey = "$rootDir/deploy_key_rsa" as File
+
+updateGitHubPages.doLast {
+    if (!gitHubAccessKey.exists()) {
+        throw new GradleException("File $gitHubAccessKey does not exist. It should be encrypted" +
+                " in the repository and decrypted on CI.")
+    }
+
+    final def GH_PAGES_BRANCH = "gh-pages"
+
+    final String repoSlug = System.getenv('REPO_SLUG')
+    if (repoSlug == null || repoSlug.isEmpty()) {
+        throw new GradleException('`REPO_SLUG` environmental variable is not set.')
+    }
+
+    /**
+     * The GitHub URL to the project repository.
+     *
+     * <p>A CI instance comes with an RSA key. However, of course, the default key has no
+     * privileges in Spine repositories. Thus, we add our own RSA key — `deploy_rsa_key`. It must
+     * have write rights in the associated repository. Also, we don't want that key to be used for
+     * anything else but GitHub Pages publishing. Thus, we configure the SSH agent to use
+     * the `deploy_rsa_key` only for specific references, namely in `github.com-publish`.
+     */
+    final String GIT_HOST = "git@github.com-publish:${repoSlug}.git"
+
+    final def repoBaseDir = "$repositoryTempDir/$GH_PAGES_BRANCH" as File
+    final def docDirPostfix = "reference/$project.name"
+    final def docDir = "$repoBaseDir/$docDirPostfix" as File
+    final def versionedDocDir = "$docDir/v/$project.version" as File
+
+    // Create SSH config file to allow pushing commits to the repository.
+    final File sshConfigFile = file("${System.getProperty("user.home")}/.ssh/config")
+    if (!sshConfigFile.exists()) {
+        final File parentDir = sshConfigFile.getCanonicalFile().getParentFile()
+        parentDir.mkdirs()
+        sshConfigFile.createNewFile()
+    }
+    sshConfigFile << """
+Host github.com-publish
+	HostName github.com
+	User git
+	IdentityFile $gitHubAccessKey.absolutePath
+"""
+    execute "$rootDir/config/scripts/register-ssh-key.sh", gitHubAccessKey.absolutePath
+
+    execute 'git', 'clone', GIT_HOST, "$repoBaseDir"
+    execute repoBaseDir, "git", "checkout", GH_PAGES_BRANCH
+    logger.debug("Updating generated documentation on GitHub Pages in directory `$docDir`")
+    docDir.mkdir()
+
+    copy {
+        from generatedDocs
+        into docDir
+    }
+
+    logger.debug("Storing the new version of documentation in directory `$versionedDocDir`")
+    versionedDocDir.mkdir()
+    copy {
+        from generatedDocs
+        into versionedDocDir
+    }
+
+    execute repoBaseDir, "git", "add", docDirPostfix
+
+    /**
+     * Publish the changes under "UpdateGitHubPages Plugin" Git user name and email stored in
+     * "FORMAL_GIT_HUB_PAGES_AUTHOR" env variable.
+     *
+     * <p>When changing the value of "FORMAL_GIT_HUB_PAGES_AUTHOR", also change the SSH private
+     * (encrypted `deploy_key_rsa`) and public ("GitHub Pages publisher (Travis CI)" on GitHub)
+     * keys.
+     */
+    execute repoBaseDir, "git", "config", "user.name", "\"UpdateGitHubPages Plugin\""
+    execute repoBaseDir, "git", "config", "user.email", System.env.FORMAL_GIT_HUB_PAGES_AUTHOR
+
+    execute repoBaseDir, "git", "commit", "--allow-empty", "--message=\"Update Javadoc for module $project.name as for version $project.version\""
+    execute repoBaseDir, "git", "push"
+    logger.debug("Updated Javadoc on GitHub Pages in directory `$docDir` sucessfully")
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
@@ -24,44 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+/**
+ * Versions of one-line dependencies.
+ *
+ * For versions of other dependencies please see `version` properties of objects declared below.
+ *
+ * See also: https://github.com/SpineEventEngine/config/issues/171
+ */
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://www.mojohaus.org/animal-sniffer/animal-sniffer-maven-plugin/
+object AnimalSniffer {
+    private const val version = "1.19"
+    const val lib = "org.codehaus.mojo:animal-sniffer-annotations:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AppEngine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AppEngine.kt
@@ -24,44 +24,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+// https://cloud.google.com/java/docs/reference
+@Suppress("unused")
+object AppEngine {
+    private const val version = "1.9.82"
+    const val sdk          = "com.google.appengine:appengine-api-1.0-sdk:${version}"
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
+    object GradlePlugin {
+        private const val version = "2.2.0"
+        const val lib = "com.google.cloud.tools:appengine-gradle-plugin:${version}"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AssertK.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AssertK.kt
@@ -24,44 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * Assertion library for tests in Kotlin
+ *
+ * [AssertK](https://github.com/willowtreeapps/assertk)
+ */
+object AssertK {
+    private const val version = "0.23.1"
+    const val libJvm = "com.willowtreeapps.assertk:assertk-jvm:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoCommon.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoCommon.kt
@@ -24,44 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://github.com/google/auto
+object AutoCommon {
+    private const val version = "1.0"
+    const val lib = "com.google.auto:auto-common:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoService.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoService.kt
@@ -24,44 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://github.com/google/auto
+object AutoService {
+    private const val version = "1.0"
+    const val annotations = "com.google.auto.service:auto-service-annotations:${version}"
+    @Suppress("unused")
+    const val processor   = "com.google.auto.service:auto-service:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoValue.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoValue.kt
@@ -24,44 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://github.com/google/auto
+object AutoValue {
+    private const val version = "1.8"
+    const val annotations = "com.google.auto.value:auto-value-annotations:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/BouncyCastle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/BouncyCastle.kt
@@ -24,44 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://www.bouncycastle.org/java.html
+object BouncyCastle {
+    const val libPkcsJdk15 = "org.bouncycastle:bcpkix-jdk15on:1.68"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
@@ -24,44 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://checkstyle.sourceforge.io/
+// See `config/gradle.checkstyle.gradle`.
+@Suppress("unused")
+object CheckStyle {
+    const val version = "8.29"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckerFramework.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckerFramework.kt
@@ -24,44 +24,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://checkerframework.org/
+object CheckerFramework {
+    private const val version = "3.12.0"
+    const val annotations = "org.checkerframework:checker-qual:${version}"
+    @Suppress("unused")
+    val dataflow = listOf(
+        "org.checkerframework:dataflow:${version}",
+        "org.checkerframework:javacutil:${version}"
+    )
+    /**
+     * This is discontinued artifact, which we do not use directly.
+     * This is a transitive dependency for us, which we force in
+     * [DependencyResolution.forceConfiguration]
+     */
+    const val compatQual = "org.checkerframework:checker-compat-qual:2.5.5"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCli.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCli.kt
@@ -24,44 +24,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * Commons CLI is a transitive dependency which we don't use directly.
+ * We `force` it in [DependencyResolution.forceConfiguration].
+ *
+ * [Commons CLI]](https://commons.apache.org/proper/commons-cli/)
+ */
+object CommonsCli {
+    private const val version = "1.4"
+    const val lib = "commons-cli:commons-cli:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsLogging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsLogging.kt
@@ -24,44 +24,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * Commons Logging is a transitive dependency which we don't use directly.
+ * We `force` it in [DependencyResolution.forceConfiguration].
+ *
+ * [Commons Logging](https://commons.apache.org/proper/commons-logging/)
+ */
+object CommonsLogging {
+    private const val version = "1.2"
+    const val lib = "commons-logging:commons-logging:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -24,44 +24,27 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+// https://errorprone.info/
+@Suppress("unused")
+object ErrorProne {
+    private const val version = "2.6.0"
+    // https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
+    private const val javacPluginVersion = "9+181-r4173-1"
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
+    val annotations = listOf(
+        "com.google.errorprone:error_prone_annotations:${version}",
+        "com.google.errorprone:error_prone_type_annotations:${version}"
+    )
+    const val core = "com.google.errorprone:error_prone_core:${version}"
+    const val checkApi = "com.google.errorprone:error_prone_check_api:${version}"
+    const val testHelpers = "com.google.errorprone:error_prone_test_helpers:${version}"
+    const val javacPlugin  = "com.google.errorprone:javac:${javacPluginVersion}"
 
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
+    object GradlePlugin {
+        const val id = "net.ltgt.errorprone"
+        const val version = "1.3.0"
+        const val lib = "net.ltgt.gradle:gradle-errorprone-plugin:${version}"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/FindBugs.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/FindBugs.kt
@@ -24,44 +24,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * The FindBugs project is dead since 2017. It has a successor called SpotBugs, but we don't use it.
+ * We use ErrorProne for static analysis instead. The only reason for having this dependency is
+ * the annotations for null-checking introduced by JSR-305. These annotations are troublesome,
+ * but no alternatives are known for some of them so far.  Please see
+ * [this issue](https://github.com/SpineEventEngine/base/issues/108) for more details.
+ */
+object FindBugs {
+    private const val version = "3.0.2"
+    const val annotations = "com.google.code.findbugs:jsr305:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Firebase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Firebase.kt
@@ -24,44 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://firebase.google.com/docs/admin/setup#java
+object Firebase {
+    private const val adminVersion = "6.12.2"
+    const val admin = "com.google.firebase:firebase-admin:${adminVersion}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
@@ -24,44 +24,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
+// https://github.com/google/flogger
+object Flogger {
+    internal const val version = "0.6"
+    const val lib     = "com.google.flogger:flogger:${version}"
+    @Suppress("unused")
+    object Runtime {
+        const val systemBackend = "com.google.flogger:flogger-system-backend:${version}"
+        const val log4J         = "com.google.flogger:flogger-log4j:${version}"
+        const val slf4J         = "com.google.flogger:slf4j-backend-factory:${version}"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -24,44 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://github.com/grpc/grpc-java
+@Suppress("unused")
+object Grpc {
+    @Suppress("MemberVisibilityCanBePrivate")
+    const val version     = "1.35.1"
+    const val core        = "io.grpc:grpc-core:${version}"
+    const val stub        = "io.grpc:grpc-stub:${version}"
+    const val okHttp      = "io.grpc:grpc-okhttp:${version}"
+    const val protobuf    = "io.grpc:grpc-protobuf:${version}"
+    const val netty       = "io.grpc:grpc-netty:${version}"
+    const val nettyShaded = "io.grpc:grpc-netty-shaded:${version}"
+    const val context     = "io.grpc:grpc-context:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
@@ -24,44 +24,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * Gson is a transitive dependency which we don't use directly.
+ * We `force` it in [DependencyResolution.forceConfiguration()].
+ *
+ * [Gson](https://github.com/google/gson)
+ */
+object Gson {
+    private const val version = "2.8.6"
+    const val lib = "com.google.code.gson:gson:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
@@ -24,44 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://github.com/google/guava
+object Guava {
+    private const val version = "30.1.1-jre"
+    const val lib     = "com.google.guava:guava:${version}"
+    const val testLib = "com.google.guava:guava-testlib:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
@@ -24,44 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * Google implementations of HTTP client.
+ */
+object HttpClient {
+    const val google = "com.google.http-client:google-http-client:1.39.1"
+    const val apache = "com.google.http-client:google-http-client-apache:2.1.2"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
@@ -24,44 +24,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * J2ObjC is a transitive dependency which we don't use directly.
+ * We `force` it in [DependencyResolution.forceConfiguration()].
+ *
+ * [J2ObjC](https://developers.google.com/j2objc)
+ */
+object J2ObjC {
+    private const val version = "1.3"
+    const val lib = "com.google.j2objc:j2objc-annotations:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
@@ -24,44 +24,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+// https://junit.org/junit5/
+object JUnit {
+    private const val version            = "5.7.1"
+    private const val platformVersion    = "1.7.1"
+    private const val legacyVersion      = "4.13.1"
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
+    // https://github.com/apiguardian-team/apiguardian
+    private const val apiGuardianVersion = "1.1.1"
+    // https://github.com/junit-pioneer/junit-pioneer
+    private const val pioneerVersion     = "1.3.8"
 
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+    const val legacy = "junit:junit:${legacyVersion}"
+    val api = listOf(
+        "org.apiguardian:apiguardian-api:${apiGuardianVersion}",
+        "org.junit.jupiter:junit-jupiter-api:${version}",
+        "org.junit.jupiter:junit-jupiter-params:${version}"
+    )
+    const val runner  = "org.junit.jupiter:junit-jupiter-engine:${version}"
+    @Suppress("unused")
+    const val pioneer = "org.junit-pioneer:junit-pioneer:${pioneerVersion}"
+    const val platformCommons = "org.junit.platform:junit-platform-commons:${platformVersion}"
+    const val platformLauncher = "org.junit.platform:junit-platform-launcher:${platformVersion}"
+    @Suppress("unused")
+    const val params = "org.junit.jupiter:junit-jupiter-params:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -24,44 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+@Suppress("unused")
+object Jackson {
+    private const val version = "2.12.3"
+    // https://github.com/FasterXML/jackson-databind
+    const val databind = "com.fasterxml.jackson.core:jackson-databind:${version}"
+    // https://github.com/FasterXML/jackson-dataformat-xml/releases
+    const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
@@ -24,44 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * A Java implementation of JSON Web Token (JWT) - RFC 7519.
+ *
+ * [Java JWT](https://github.com/auth0/java-jwt)
+ */
+object JavaJwt {
+    private const val version = "3.14.0"
+    const val lib = "com.auth0:java-jwt:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaPoet.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaPoet.kt
@@ -24,44 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://github.com/square/javapoet
+object JavaPoet {
+    private const val version = "1.13.0"
+    const val lib = "com.squareup:javapoet:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaX.kt
@@ -24,44 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// This artifact which used to be a part of J2EE moved under Eclipse EE4J project.
+// https://github.com/eclipse-ee4j/common-annotations-api
+object JavaX {
+    const val annotations = "javax.annotation:javax.annotation-api:1.3.2"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Klaxon.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Klaxon.kt
@@ -24,44 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * A JSON parser in Kotlin
+ *
+ * [Klaxon](https://github.com/cbeust/klaxon)
+ */
+object Klaxon {
+    private const val version = "5.4"
+    const val lib = "com.beust:klaxon:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -24,44 +24,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://github.com/JetBrains/kotlin
+// https://github.com/Kotlin
+object Kotlin {
+    @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
+    const val version      = "1.5.0"
+    const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
+    const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
+    const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"
+    const val stdLibJdk8   = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/LicenseReport.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/LicenseReport.kt
@@ -24,44 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+// https://github.com/jk1/Gradle-License-Report
+@Suppress("unused")
+object LicenseReport {
+    private const val version = "1.16"
+    const val lib = "com.github.jk1:gradle-license-report:${version}"
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
+    object GradlePlugin {
+        const val version = LicenseReport.version
+        const val id = "com.github.jk1.dependency-license-report"
+        const val lib = LicenseReport.lib
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Okio.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Okio.kt
@@ -24,44 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * Okio is a transitive dependency which we don't use directly.
+ * We `force` it in [DependencyResolution.forceConfiguration].
+ */
+object Okio {
+    // This is the last version before next major.
+    private const val version = "1.17.5"
+    const val lib = "com.squareup.okio:okio:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
@@ -24,44 +24,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * Plexus Utils is a transitive dependency which we don't use directly.
+ * We `force` it in [DependencyResolution.forceConfiguration].
+ *
+ * [Plexus Utils](https://codehaus-plexus.github.io/plexus-utils/)
+ */
+object Plexus {
+    private const val version = "3.3.0"
+    const val utils = "org.codehaus.plexus:plexus-utils:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
@@ -24,44 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://pmd.github.io/
+@Suppress("unused") // Will be used when `config/gradle/pmd.gradle` migrates to Kotlin.
+object Pmd {
+    const val version = "6.33.0"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -24,44 +24,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+// https://github.com/protocolbuffers/protobuf
+@Suppress("MemberVisibilityCanBePrivate") // used directly from outside
+object Protobuf {
+    const val version    = "3.15.7"
+    val libs = listOf(
+        "com.google.protobuf:protobuf-java:${version}",
+        "com.google.protobuf:protobuf-java-util:${version}"
+    )
+    const val compiler = "com.google.protobuf:protoc:${version}"
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
+    object GradlePlugin {
+        const val version = "0.8.13"
+        const val id = "com.google.protobuf"
+        const val lib = "com.google.protobuf:protobuf-gradle-plugin:${version}"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -24,44 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://github.com/forge/roaster
+object Roaster {
+    private const val version = "2.22.2.Final"
+    const val api = "org.jboss.forge.roaster:roaster-api:${version}"
+    const val jdt = "org.jboss.forge.roaster:roaster-jdt:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Slf4J.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Slf4J.kt
@@ -24,44 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+/**
+ * Spine used to log with SLF4J. Now we use Flogger. Whenever a choice comes up, we recommend to
+ * use the latter.
+ *
+ * Some third-party libraries may clash with different versions of the library. Thus, we specify
+ * this version and force it via [forceConfiguration(..)][DependencyResolution.forceConfiguration].
+ */
+@Deprecated("Use Flogger over SLF4J.", replaceWith = ReplaceWith("flogger"))
+object Slf4J {
+    private const val version = "1.7.30"
+    const val lib = "org.slf4j:slf4j-api:${version}"
+    const val jdk14 = "org.slf4j:slf4j-jdk14:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
@@ -24,44 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.dependency
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+// https://github.com/google/truth
+object Truth {
+    private const val version = "1.1.2"
+    val libs = listOf(
+        "com.google.truth:truth:${version}",
+        "com.google.truth.extensions:truth-java8-extension:${version}",
+        "com.google.truth.extensions:truth-proto-extension:${version}"
+    )
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Build.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Build.kt
@@ -24,44 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.gradle
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
-
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+@Suppress("unused")
+object Build {
+    val ci = "true".equals(System.getenv("CI"))
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle
+
+import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.FileNotFoundException
+import java.net.URL
+
+/**
+ * A task which verifies that the current version of the library has not been published to the given
+ * Maven repository yet.
+ */
+open class CheckVersionIncrement : DefaultTask() {
+
+    /**
+     * The Maven repository in which to look for published artifacts.
+     *
+     * We only check the `releases` repository. Artifacts in `snapshots` repository still may be
+     * overridden.
+     */
+    @Input
+    lateinit var repository: Repository
+
+    @Input
+    val version: String = project.version as String
+
+    @TaskAction
+    private fun fetchAndCheck() {
+        val artifact = "${project.artifactPath()}/${MavenMetadata.FILE_NAME}"
+        val repoUrl = repository.releases
+        val metadata = fetch(repoUrl, artifact)
+        val versions = metadata?.versioning?.versions
+        val versionExists = versions?.contains(version) ?: false
+        if (versionExists) {
+            throw GradleException("""
+                    Version `$version` is already published to maven repository `$repoUrl`.
+                    Try incrementing the library version.
+                    All available versions are: ${versions?.joinToString(separator = ", ")}. 
+                    
+                    To disable this check, run Gradle with `-x $name`. 
+                    """.trimIndent()
+            )
+        }
+    }
+
+    private fun fetch(repository: String, artifact: String): MavenMetadata? {
+        val url = URL("$repository/$artifact")
+        return MavenMetadata.fetchAndParse(url)
+    }
+
+    private fun Project.artifactPath(): String {
+        val group = this.group as String
+        val name = "spine-${this.name}"
+
+        val pathElements = ArrayList(group.split('.'))
+        pathElements.add(name)
+        val path = pathElements.joinToString(separator = "/")
+        return path
+    }
+}
+
+private data class MavenMetadata(var versioning: Versioning = Versioning()) {
+
+    companion object {
+
+        const val FILE_NAME = "maven-metadata.xml"
+
+        private val mapper = XmlMapper()
+
+        init {
+            mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+        }
+
+        /**
+         * Fetches the metadata for the repository and parses the document.
+         *
+         * <p>If the document could not be found, assumes that the module was never
+         * released and thus has no metadata.
+         */
+        fun fetchAndParse(url: URL): MavenMetadata? {
+            return try {
+                val metadata = mapper.readValue(url, MavenMetadata::class.java)
+                metadata
+            } catch (e: FileNotFoundException) {
+                null
+            }
+        }
+    }
+}
+
+private data class Versioning(var versions: List<String> = listOf())

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle
+
+import io.spine.internal.dependency.AnimalSniffer
+import io.spine.internal.dependency.AutoCommon
+import io.spine.internal.dependency.AutoService
+import io.spine.internal.dependency.AutoValue
+import io.spine.internal.dependency.CheckerFramework
+import io.spine.internal.dependency.CommonsCli
+import io.spine.internal.dependency.CommonsLogging
+import io.spine.internal.dependency.ErrorProne
+import io.spine.internal.dependency.FindBugs
+import io.spine.internal.dependency.Gson
+import io.spine.internal.dependency.Guava
+import io.spine.internal.dependency.J2ObjC
+import io.spine.internal.dependency.JUnit
+import io.spine.internal.dependency.Kotlin
+import io.spine.internal.dependency.Okio
+import io.spine.internal.dependency.Plexus
+import io.spine.internal.dependency.Protobuf
+import io.spine.internal.dependency.Truth
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.ResolutionStrategy
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+
+/**
+ * The function to be used in `buildscript` when a fully-qualified call must be made.
+ */
+@Suppress("unused")
+fun doForceVersions(configurations: ConfigurationContainer) {
+    configurations.forceVersions()
+}
+
+/**
+ * Forces dependencies used in the project.
+ */
+fun ConfigurationContainer.forceVersions() {
+    all {
+        resolutionStrategy {
+            failOnVersionConflict()
+            cacheChangingModulesFor(0, "seconds")
+            forceProductionDependencies()
+            forceTestDependencies()
+            forceTransitiveDependencies()
+        }
+    }
+}
+
+private fun ResolutionStrategy.forceProductionDependencies() {
+    @Suppress("DEPRECATION") // Force SLF4J version.
+    force(
+        AnimalSniffer.lib,
+        AutoCommon.lib,
+        AutoService.annotations,
+        CheckerFramework.annotations,
+        ErrorProne.annotations,
+        Guava.lib,
+        FindBugs.annotations,
+        Kotlin.reflect,
+        Kotlin.stdLib,
+        Kotlin.stdLibCommon,
+        Kotlin.stdLibJdk8,
+        Protobuf.libs,
+        Protobuf.GradlePlugin.lib,
+        io.spine.internal.dependency.Slf4J.lib
+    )
+}
+
+private fun ResolutionStrategy.forceTestDependencies() {
+    force(
+        Guava.testLib,
+        JUnit.api,
+        JUnit.platformCommons,
+        JUnit.platformLauncher,
+        JUnit.legacy,
+        Truth.libs
+    )
+}
+
+/**
+ * Forces transitive dependencies of 3rd party components that we don't use directly.
+ */
+private fun ResolutionStrategy.forceTransitiveDependencies() {
+    force(
+        AutoValue.annotations,
+        Gson.lib,
+        J2ObjC.lib,
+        Plexus.utils,
+        Okio.lib,
+        CommonsCli.lib,
+        CheckerFramework.compatQual,
+        CommonsLogging.lib
+    )
+}
+
+fun ConfigurationContainer.excludeProtobufLite() {
+
+    fun excludeProtoLite(configurationName: String) {
+        named(configurationName).get().exclude(
+            mapOf(
+                "group" to "com.google.protobuf",
+                "module" to "protobuf-lite"
+            )
+        )
+    }
+
+    excludeProtoLite("runtime")
+    excludeProtoLite("testRuntime")
+}
+
+@Suppress("unused")
+object DependencyResolution {
+    @Deprecated(
+        "Please use `configurations.forceVersions()`.",
+        ReplaceWith("configurations.forceVersions()")
+    )
+    fun forceConfiguration(configurations: ConfigurationContainer) {
+        configurations.forceVersions()
+    }
+
+    @Deprecated(
+        "Please use `configurations.excludeProtobufLite()`.",
+        ReplaceWith("configurations.excludeProtobufLite()")
+    )
+    fun excludeProtobufLite(configurations: ConfigurationContainer) {
+        configurations.excludeProtobufLite()
+    }
+
+    @Deprecated(
+        "Please use `applyStandard(repositories)` instead.",
+        replaceWith = ReplaceWith("applyStandard(repositories)")
+    )
+    fun defaultRepositories(repositories: RepositoryHandler) {
+        repositories.applyStandard()
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/IncrementGuard.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:Suppress("unused")
+
+package io.spine.internal.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Gradle plugin which adds a [CheckVersionIncrement] task.
+ *
+ * The task is called `checkVersionIncrement` inserted before the `check` task.
+ */
+class IncrementGuard : Plugin<Project> {
+
+    companion object {
+        const val taskName = "checkVersionIncrement"
+    }
+
+    /**
+     * Adds the [CheckVersionIncrement] task to the project.
+     *
+     * Only adds the check if the project is built on Travis CI and the job is a pull request.
+     *
+     * The task only runs on non-master branches on GitHub Actions. This is done
+     * to prevent unexpected CI fails when re-building `master` multiple times, creating git
+     * tags, and in other cases that go outside of the "usual" development cycle.
+     */
+    override fun apply(target: Project) {
+        val tasks = target.tasks
+        tasks.register(taskName, CheckVersionIncrement::class.java) {
+            repository = PublishingRepos.cloudRepo
+            tasks.getByName("check").dependsOn(this)
+
+            shouldRunAfter("test")
+            if (!shouldCheckVersion()) {
+                logger.info(
+                    "The build does not represent a GitHub Actions feature branch job, " +
+                            "the `checkVersionIncrement` task is disabled."
+                )
+                this.enabled = false
+            }
+        }
+    }
+
+    /**
+     * Returns `true` if the current build is a GitHub Actions build which represents a push
+     * to a feature branch.
+     *
+     * Returns `false` if the associated reference is not a branch (e.g. a tag) or if it has
+     * the name which ends with `master`. So, on branches such as `master` and `2.x-jdk8-master`
+     * this method would return `false`.
+     *
+     * @see <a href="https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables">
+     *     List of default environment variables provided for GitHub Actions builds</a>
+     */
+    private fun shouldCheckVersion(): Boolean {
+        val eventName = System.getenv("GITHUB_EVENT_NAME")
+        if ("push" != eventName) {
+            return false
+        }
+        val reference = System.getenv("GITHUB_REF") ?: return false
+        val matches = Regex("refs/heads/(.+)").matchEntire(reference) ?: return false
+        val branch = matches.groupValues[1]
+        return !branch.endsWith("master")
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle
+
+import io.spine.internal.gradle.DefaultArtifact.javadocJar
+import io.spine.internal.gradle.DefaultArtifact.sourceJar
+import io.spine.internal.gradle.DefaultArtifact.testOutputJar
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.file.FileCollection
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.getPlugin
+import org.gradle.kotlin.dsl.property
+import org.gradle.kotlin.dsl.setProperty
+
+/**
+ * This plugin allows to publish artifacts to remote Maven repositories.
+ *
+ * Apply this plugin to the root project. Specify the projects which produce publishable artifacts
+ * and the target Maven repositories via the `publishing` DSL:
+ * ```
+ * import io.spine.gradle.internal.PublishingRepos
+ * import io.spine.gradle.internal.spinePublishing
+ *
+ * spinePublishing {
+ *     projectsToPublish.addAll(
+ *         "submodule1",
+ *         "submodule2",
+ *         "nested:submodule3"
+ *     )
+ *     targetRepositories.addAll(
+ *         PublishingRepos.cloudRepo,
+ *         PublishingRepos.gitHub("LibraryName")
+ *     )
+ * }
+ * ```
+ *
+ * By default, we publish artifacts produced by tasks `sourceJar`, `testOutputJar`,
+ * and `javadocJar`, along with the default project compilation output. If any of these tasks is not
+ * declared, it's created with sensible default settings by the plugin.
+ *
+ * To publish more artifacts for a certain project, add them to the archives configuration:
+ * ```
+ * artifacts {
+ *     archives(myCustomJarTask)
+ * }
+ * ```
+ *
+ * If any plugins applied to the published project declare any other artifacts, those artifacts
+ * are published as well.
+ */
+class Publish : Plugin<Project> {
+
+    companion object {
+
+        const val taskName = "publish"
+        const val extensionName = "spinePublishing"
+
+        private const val ARCHIVES = "archives"
+    }
+
+    override fun apply(project: Project) {
+        val extension = PublishExtension.create(project)
+        project.extensions.add(PublishExtension::class.java, extensionName, extension)
+
+        val publish = project.createPublishTask()
+        val checkCredentials = project.createCheckTask(extension)
+
+        project.afterEvaluate {
+            extension.projectsToPublish
+                .get()
+                .map { project.project(it) }
+                .forEach { p ->
+                    p.logger.debug("Applying `maven-publish` plugin to ${name}.")
+
+                    p.apply(plugin = "maven-publish")
+
+                    p.setUpDefaultArtifacts()
+
+                    val action = {
+                        val publishingExtension = p.extensions.getByType(PublishingExtension::class)
+                        publishingExtension.createMavenPublication(p, extension)
+                        publishingExtension.setUpRepositories(p, extension)
+                        p.prepareTasks(publish, checkCredentials)
+                    }
+                    if (p.state.executed) {
+                        action()
+                    } else {
+                        p.afterEvaluate { action() }
+                    }
+                }
+        }
+    }
+
+    private fun Project.createPublishTask(): Task =
+        rootProject.tasks.create(taskName)
+
+    private fun Project.createCheckTask(extension: PublishExtension): Task {
+        val checkCredentials = tasks.create("checkCredentials")
+        checkCredentials.doLast {
+            extension.targetRepositories
+                .get()
+                .forEach {
+                    it.credentials(this@createCheckTask)
+                        ?: throw InvalidUserDataException(
+                            "No valid credentials for repository `${it}`. Please make sure " +
+                                    "to pass username/password or a valid `.properties` file."
+                        )
+                }
+        }
+        return checkCredentials
+    }
+
+    private fun Project.prepareTasks(publish: Task, checkCredentials: Task) {
+        val publishTasks = getTasksByName(taskName, false)
+        publish.dependsOn(publishTasks)
+        publishTasks.forEach { it.dependsOn(checkCredentials) }
+    }
+
+    private fun Project.setUpDefaultArtifacts() {
+        val javaConvention = project.convention.getPlugin(JavaPluginConvention::class)
+        val sourceSets = javaConvention.sourceSets
+
+        val sourceJar = tasks.createIfAbsent(
+            artifactTask = sourceJar,
+            from = sourceSets["main"].allSource,
+            classifier = "sources"
+        )
+        val testOutputJar = tasks.createIfAbsent(
+            artifactTask = testOutputJar,
+            from = sourceSets["test"].output,
+            classifier = "test"
+        )
+        val javadocJar = tasks.createIfAbsent(
+            artifactTask = javadocJar,
+            from = files("$buildDir/docs/javadoc"),
+            classifier = "javadoc",
+            dependencies = setOf("javadoc")
+        )
+
+        artifacts {
+            add(ARCHIVES, sourceJar)
+            add(ARCHIVES, testOutputJar)
+            add(ARCHIVES, javadocJar)
+        }
+    }
+
+    private fun TaskContainer.createIfAbsent(artifactTask: DefaultArtifact,
+                                             from: FileCollection,
+                                             classifier: String,
+                                             dependencies: Set<Any> = setOf()): Task {
+        val existing = findByName(artifactTask.name)
+        if (existing != null) {
+            return existing
+        }
+        return create(artifactTask.name, Jar::class) {
+            this.from(from)
+            archiveClassifier.set(classifier)
+            dependencies.forEach { dependsOn(it) }
+        }
+    }
+
+    private fun PublishingExtension.createMavenPublication(project: Project,
+                                                           extension: PublishExtension
+    ) {
+        val artifactIdForPublishing = if (extension.spinePrefix.get()) {
+            "spine-${project.name}"
+        } else {
+            project.name
+        }
+        publications {
+            create("mavenJava", MavenPublication::class.java) {
+                groupId = project.group.toString()
+                artifactId = artifactIdForPublishing
+                version = project.version.toString()
+
+                from(project.components.getAt("java"))
+
+                setArtifacts(project.configurations.getAt(ARCHIVES).allArtifacts)
+            }
+        }
+    }
+
+    private fun PublishingExtension.setUpRepositories(
+        project: Project,
+        extension: PublishExtension
+    ) {
+        val snapshots = project.version
+            .toString()
+            .matches(Regex(".+[-.]SNAPSHOT([+.]\\d+)?"))
+        repositories {
+            extension.targetRepositories.get().forEach { repo ->
+                maven {
+                    initialize(repo, project, snapshots)
+                }
+            }
+        }
+    }
+
+    private fun MavenArtifactRepository.initialize(repo: Repository,
+                                                   project: Project,
+                                                   snapshots: Boolean) {
+        val publicRepo = if(snapshots) {
+            repo.snapshots
+        } else {
+            repo.releases
+        }
+        // Special treatment for CloudRepo URL.
+        // Reading is performed via public repositories, and publishing via
+        // private ones that differ in the `/public` infix.
+        url = project.uri(publicRepo.replace("/public", ""))
+        val creds = repo.credentials(project.rootProject)
+        credentials {
+            username = creds?.username
+            password = creds?.password
+        }
+    }
+}
+
+/**
+ * The extension for configuring the `Publish` plugin.
+ */
+class PublishExtension
+private constructor(
+    val projectsToPublish: SetProperty<String>,
+    val targetRepositories: SetProperty<Repository>,
+    val spinePrefix: Property<Boolean>
+) {
+
+    internal companion object {
+        fun create(project: Project): PublishExtension {
+            val factory = project.objects
+            return PublishExtension(
+                projectsToPublish = factory.setProperty(String::class),
+                targetRepositories = factory.setProperty(Repository::class),
+                spinePrefix = factory.property(Boolean::class)
+            )
+        }
+    }
+
+    init {
+        spinePrefix.convention(true)
+    }
+}
+
+/**
+ * Configures the `spinePublishing` extension.
+ *
+ * As `Publish` is a class-plugin in `buildSrc`, we don't get strongly typed generated helper
+ * methods for the `spinePublishing` configuration. Thus, we proviude this helper function for use
+ * in Kotlin build scripts.
+ */
+@Suppress("unused")
+fun Project.spinePublishing(action: PublishExtension.() -> Unit) {
+    apply<Publish>()
+
+    val extension = extensions.getByType(PublishExtension::class)
+    extension.action()
+}
+
+/**
+ * Default artifact task names.
+ *
+ * These tasks, if not present on a project already, are created by the `Publish` plugin. Their
+ * output is published as project's artifacts.
+ */
+private enum class DefaultArtifact {
+
+    sourceJar,
+    testOutputJar,
+    javadocJar;
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publishing.kt
@@ -24,44 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.gradle
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+import io.spine.internal.dependency.AssertK
+import io.spine.internal.dependency.BouncyCastle
+import io.spine.internal.dependency.JavaJwt
+import io.spine.internal.dependency.Klaxon
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+@Suppress("unused")
+object Publishing {
+    const val klaxon = Klaxon.lib
+    const val oauthJwt = JavaJwt.lib
+    const val bouncyCastlePkcs = BouncyCastle.libPkcsJdk15
+    const val assertK = AssertK.libJvm
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle
+
+import java.io.File
+import java.net.URI
+import java.util.*
+import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+
+/**
+ * A Maven repository.
+ */
+data class Repository(
+    val releases: String,
+    val snapshots: String,
+    private val credentialsFile: String? = null,
+    private val credentials: Credentials? = null,
+    val name: String = "Maven repository `$releases`"
+) {
+
+    /**
+     * Obtains the publishing password credentials to this repository.
+     *
+     * If the credentials are represented by a `.properties` file, reads the file and parses
+     * the credentials. The file must have properties `user.name` and `user.password`, which store
+     * the username and the password for the Maven repository auth.
+     */
+    fun credentials(project: Project): Credentials? {
+        if (credentials != null) {
+            return credentials
+        }
+        credentialsFile!!
+        val log = project.logger
+        log.info("Using credentials from `$credentialsFile`.")
+        val file = project.rootProject.file(credentialsFile)
+        if (!file.exists()) {
+            return null
+        }
+        val creds = file.readCredentials()
+        log.info("Publishing build as `${creds.username}`.")
+        return creds
+    }
+
+    private fun File.readCredentials(): Credentials {
+        val properties = Properties()
+        properties.load(inputStream())
+        val username = properties.getProperty("user.name")
+        val password = properties.getProperty("user.password")
+        return Credentials(username, password)
+    }
+
+    override fun toString(): String {
+        return name
+    }
+}
+
+/**
+ * Password credentials for a Maven repository.
+ */
+data class Credentials(
+    val username: String?,
+    val password: String?
+)
+
+/**
+ * Repositories to which we may publish. Normally, only one repository will be used.
+ *
+ * See `publish.gradle` for details of the publishing process.
+ */
+object PublishingRepos {
+
+    @Suppress("HttpUrlsUsage") // HTTPS is not supported by this repository.
+    val mavenTeamDev = Repository(
+        name = "maven.teamdev.com",
+        releases = "http://maven.teamdev.com/repository/spine",
+        snapshots = "http://maven.teamdev.com/repository/spine-snapshots",
+        credentialsFile = "credentials.properties"
+    )
+    val cloudRepo = Repository(
+        name = "CloudRepo",
+        releases = "https://spine.mycloudrepo.io/public/repositories/releases",
+        snapshots = "https://spine.mycloudrepo.io/public/repositories/snapshots",
+        credentialsFile = "cloudrepo.properties"
+    )
+
+    fun gitHub(repoName: String): Repository {
+        return Repository(
+            name = "GitHub Packages",
+            releases = "https://maven.pkg.github.com/SpineEventEngine/$repoName",
+            snapshots = "https://maven.pkg.github.com/SpineEventEngine/$repoName",
+            credentials = Credentials(
+                username = System.getenv("GITHUB_ACTOR"),
+                // This is a trick. Gradle only supports password or AWS credentials. Thus,
+                // we pass the GitHub token as a "password".
+                // https://docs.github.com/en/actions/guides/publishing-java-packages-with-gradle#publishing-packages-to-github-packages
+                password = System.getenv("GITHUB_TOKEN")
+            )
+        )
+    }
+}
+
+/**
+ * Defines names of additional repositories commonly used in the framework projects.
+ *
+ * @see [applyStandard]
+ */
+@Suppress("unused")
+object Repos {
+    val oldSpine: String = PublishingRepos.mavenTeamDev.releases
+    val oldSpineSnapshots: String = PublishingRepos.mavenTeamDev.snapshots
+
+    val spine: String = PublishingRepos.cloudRepo.releases
+    val spineSnapshots: String = PublishingRepos.cloudRepo.snapshots
+
+    const val sonatypeReleases: String = "https://oss.sonatype.org/content/repositories/snapshots"
+    const val sonatypeSnapshots: String = "https://oss.sonatype.org/content/repositories/snapshots"
+}
+
+/**
+ * The function to be used in `buildscript` clauses when fully-qualified call must be made.
+ */
+@Suppress("unused")
+fun doApplyStandard(repositories: RepositoryHandler) {
+    repositories.applyStandard()
+}
+
+/**
+ * Applies repositories commonly used by Spine Event Engine projects.
+ */
+@Suppress("unused")
+fun RepositoryHandler.applyStandard() {
+
+    apply {
+        gradlePluginPortal()
+        mavenLocal()
+
+        val libraryGroup = "io.spine"
+        val toolsGroup = "io.spine.tools"
+        val gcloudGroup = "io.spine.gcloud"
+
+        maven {
+            url = URI(Repos.spine)
+            content {
+                includeGroup(libraryGroup)
+                includeGroup(toolsGroup)
+                includeGroup(gcloudGroup)
+            }
+        }
+        maven {
+            url = URI(Repos.spineSnapshots)
+            content {
+                includeGroup(libraryGroup)
+                includeGroup(toolsGroup)
+                includeGroup(gcloudGroup)
+            }
+        }
+        mavenCentral()
+        maven {
+            url = URI(Repos.sonatypeReleases)
+        }
+        maven {
+            url = URI(Repos.sonatypeSnapshots)
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle
+
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.os.OperatingSystem
+
+/**
+ * A Gradle task which runs another Gradle build.
+ *
+ * Launches Gradle wrapper under a given [directory] with the `build` task. The `clean` task is also
+ * run if current build includes a `clean` task.
+ *
+ * The build writes verbose log into `$directory/build/debug-out.txt`. The error output is written
+ * into `$directory/build/error-out.txt`.
+ */
+@Suppress("unused")
+open class RunBuild : DefaultTask() {
+
+    /**
+     * Path to the directory which contains a Gradle wrapper script.
+     */
+    @Internal
+    lateinit var directory: String
+
+    @TaskAction
+    private fun execute() {
+        val runsOnWindows = OperatingSystem.current().isWindows()
+        val script = if (runsOnWindows) "gradlew.bat" else "gradlew"
+        val command = buildCommand(script)
+
+        // Ensure build error output log.
+        // Since we're executing this task in another process, we redirect error output to
+        // the file under the `build` directory.
+        val buildDir = File(directory, "build")
+        if (!buildDir.exists()) {
+            buildDir.mkdir()
+        }
+        val errorOut = File(buildDir, "error-out.txt")
+        val debugOut = File(buildDir, "debug-out.txt")
+
+        val process = buildProcess(command, errorOut, debugOut)
+        if (process.waitFor() != 0) {
+            throw GradleException("Build FAILED. See $errorOut for details.")
+        }
+    }
+
+    private fun buildCommand(script: String): List<String> {
+        val command = mutableListOf<String>()
+        command.add("${project.rootDir}/$script")
+        val shouldClean = project.gradle
+                                 .taskGraph
+                                 .hasTask(":clean")
+        if (shouldClean) {
+            command.add("clean")
+        }
+        command.add("build")
+        command.add("--console=plain")
+        command.add("--debug")
+        command.add("--stacktrace")
+        return command
+    }
+
+    private fun buildProcess(command: List<String>, errorOut: File, debugOut: File) =
+        ProcessBuilder()
+            .command(command)
+            .directory(project.file(directory))
+            .redirectError(errorOut)
+            .redirectOutput(debugOut)
+            .start()
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
@@ -24,44 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+package io.spine.internal.gradle
 
-plugins {
-    dart
-    id("io.spine.tools.proto-dart-plugin")
-}
+import io.spine.internal.dependency.Flogger
 
-apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-}
-
-val spineBaseVersion: String by extra
-
-dependencies {
-    protobuf("io.spine:spine-base:$spineBaseVersion")
-    protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
-
-tasks["testDart"].enabled = false
-
-protobuf {
-    generateProtoTasks {
-        all().forEach { task ->
-            task.plugins {
-                id("dart")
-            }
-            task.builtins {
-                remove("java")
-            }
-        }
-    }
+object Runtime {
+    @Suppress("unused")
+    val flogger = Flogger.Runtime
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Scripts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Scripts.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle
+
+import org.gradle.api.Project
+
+@Suppress("unused")
+object Scripts {
+    @Suppress("MemberVisibilityCanBePrivate") // is used from Groovy-based scripts.
+    const val commonPath = "/buildSrc/src/main/groovy/"
+
+    fun testArtifacts(p: Project)          = p.script("test-artifacts.gradle")
+    fun testOutput(p: Project)             = p.script("test-output.gradle")
+    fun slowTests(p: Project)              = p.script("slow-tests.gradle")
+    fun javadocOptions(p: Project)         = p.script("javadoc-options.gradle")
+    fun filterInternalJavadocs(p: Project) = p.script("filter-internal-javadoc.gradle")
+    fun jacoco(p: Project)                 = p.script("jacoco.gradle")
+    fun publish(p: Project)                = p.script("publish.gradle")
+    fun publishProto(p: Project)           = p.script("publish-proto.gradle")
+    fun javacArgs(p: Project)              = p.script("javac-args.gradle")
+    fun jsBuildTasks(p: Project)           = p.script("js/build-tasks.gradle")
+    fun jsConfigureProto(p: Project)       = p.script("js/configure-proto.gradle")
+    fun npmPublishTasks(p: Project)        = p.script("js/npm-publish-tasks.gradle")
+    fun npmCli(p: Project)                 = p.script("js/npm-cli.gradle")
+    fun updatePackageVersion(p: Project)   = p.script("js/update-package-version.gradle")
+    fun dartBuildTasks(p: Project)         = p.script("dart/build-tasks.gradle")
+    fun pubPublishTasks(p: Project)        = p.script("dart/pub-publish-tasks.gradle")
+    fun pmd(p: Project)                    = p.script("pmd.gradle")
+    fun checkstyle(p: Project)             = p.script("checkstyle.gradle")
+    fun runBuild(p: Project)               = p.script("run-build.gradle")
+    fun modelCompiler(p: Project)          = p.script("model-compiler.gradle")
+    fun licenseReportCommon(p: Project)    = p.script("license-report-common.gradle")
+    fun projectLicenseReport(p: Project)   = p.script("license-report-project.gradle")
+    fun repoLicenseReport(p: Project)      = p.script("license-report-repo.gradle")
+    fun generatePom(p: Project)            = p.script("generate-pom.gradle")
+    fun updateGitHubPages(p: Project)      = p.script("update-gh-pages.gradle")
+
+    private fun Project.script(name: String) = "${rootDir}$commonPath${name}"
+}

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -37,3 +37,7 @@
 
  The required language level is bumped to `2.7.0` or above (previous was `2.5.0` or above). Now
  the language features used in the companion CLI tool match the expected level.
+
+## 1.7.3
+ This release introduces null-safe API, according to the new Dart null safety feature.
+ The Dart language version is promoted to `2.13`.

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -32,7 +32,7 @@ import com.google.protobuf.gradle.plugins
 import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.remove
 import com.google.protobuf.gradle.testProtobuf
-import io.spine.internal.gradle.Scripts
+import io.spine.gradle.internal.Deps
 
 plugins {
     java
@@ -41,10 +41,10 @@ plugins {
 }
 
 apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
-    from(Scripts.javadocOptions(project))
-    from(Scripts.updateGitHubPages(project))
+    from(Deps.scripts.dartBuildTasks(project))
+    from(Deps.scripts.pubPublishTasks(project))
+    from(Deps.scripts.javadocOptions(project))
+    from(Deps.scripts.updateGitHubPages(project))
 }
 
 val spineBaseVersion: String by extra

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -32,7 +32,7 @@ import com.google.protobuf.gradle.plugins
 import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.remove
 import com.google.protobuf.gradle.testProtobuf
-import io.spine.gradle.internal.Deps
+import io.spine.internal.gradle.Scripts
 
 plugins {
     java
@@ -41,10 +41,10 @@ plugins {
 }
 
 apply {
-    from(Deps.scripts.dartBuildTasks(project))
-    from(Deps.scripts.pubPublishTasks(project))
-    from(Deps.scripts.javadocOptions(project))
-    from(Deps.scripts.updateGitHubPages(project))
+    from(Scripts.dartBuildTasks(project))
+    from(Scripts.pubPublishTasks(project))
+    from(Scripts.javadocOptions(project))
+    from(Scripts.updateGitHubPages(project))
 }
 
 val spineBaseVersion: String by extra

--- a/client/lib/src/actor_request_factory.dart
+++ b/client/lib/src/actor_request_factory.dart
@@ -37,9 +37,9 @@ import 'package:spine_client/time.dart' as time;
 class ActorRequestFactory {
 
     final UserId actor;
-    final TenantId tenant;
-    final ZoneOffset zoneOffset;
-    final ZoneId zoneId;
+    final TenantId? tenant;
+    final ZoneOffset? zoneOffset;
+    final ZoneId? zoneId;
 
     /// Creates a new [ActorRequestFactory].
     ///
@@ -49,7 +49,10 @@ class ActorRequestFactory {
     ///
     /// In multitenant systems, it's required for all the actor requests to have a [tenant] ID.
     ///
-    ActorRequestFactory(this.actor, [this.tenant, this.zoneOffset, this.zoneId]);
+    ActorRequestFactory(this.actor,
+                       [this.tenant = null,
+                        this.zoneOffset = null,
+                        this.zoneId = null]);
 
     /// Creates a factory of queries to the server.
     QueryFactory query() {

--- a/client/lib/src/any_packer.dart
+++ b/client/lib/src/any_packer.dart
@@ -46,7 +46,7 @@ GeneratedMessage unpack(Any any) {
     if (builder == null) {
         throw UnknownTypeError(typeUrl: typeUrl);
     }
-    var emptyInstance = builder.createEmptyInstance();
+    var emptyInstance = builder.createEmptyInstance!.call();
     return any.unpackInto(emptyInstance);
 }
 
@@ -109,7 +109,7 @@ Any packObject(Object value) {
     } else if (value is bool) {
         return pack(BoolValue()..value = value);
     } else if (value is List && (value.isEmpty || value[0] is int)) {
-        return pack(BytesValue()..value = value);
+        return pack(BytesValue()..value = value as List<int>);
     } else {
         throw ArgumentError('Instance of type ${value.runtimeType} cannot be '
                             'packed into a `google.protobuf.Any`.');

--- a/client/lib/src/http_client.dart
+++ b/client/lib/src/http_client.dart
@@ -50,7 +50,7 @@ class HttpClient {
     ///
     Future<http.Response> postMessage(String path, GeneratedMessage message) {
         var bytes = message.writeToBuffer();
-        var url = Url.from(_baseUrl, path).stringUrl;
+        var url = Url.from(_baseUrl, path).asUri;
         var response = http.post(url, body: _base64.encode(bytes), headers: _protobufContentType);
         return response;
     }

--- a/client/lib/src/json.dart
+++ b/client/lib/src/json.dart
@@ -42,7 +42,7 @@ void parseInto(GeneratedMessage message, String json) {
 
 /// Parses the given JSON string into a new instance of the message described by the [builder].
 T parseIntoNewInstance<T extends GeneratedMessage>(BuilderInfo builder, String json) {
-    var msg = builder.createEmptyInstance();
+    var msg = builder.createEmptyInstance!.call();
     parseInto(msg, json);
-    return msg;
+    return msg as T;
 }

--- a/client/lib/src/known_types.dart
+++ b/client/lib/src/known_types.dart
@@ -57,7 +57,7 @@ class KnownTypes {
     ///
     /// Returns `null` if the type is unknown.
     ///
-    BuilderInfo findBuilderInfo(String typeUrl) {
+    BuilderInfo? findBuilderInfo(String typeUrl) {
         return _typeUrlToBuilderInfo[typeUrl];
     }
 
@@ -84,7 +84,7 @@ class KnownTypes {
     /// Obtains a validator function for the given message.
     ValidationError Function(GeneratedMessage) validatorFor(GeneratedMessage message) {
         var typeUrl = typeUrlOf(message);
-        return _validators[typeUrl];
+        return _validators[typeUrl]!;
     }
 
     /// Obtains a registry for JSON parsing.

--- a/client/lib/src/query_factory.dart
+++ b/client/lib/src/query_factory.dart
@@ -43,9 +43,9 @@ class QueryFactory {
     Query build(Type type,
                 {Iterable<Object> ids = const [],
                  Iterable<CompositeFilter> filters = const [],
-                 FieldMask fieldMask,
-                 OrderBy orderBy,
-                 int limit}) {
+                 FieldMask? fieldMask = null,
+                 OrderBy? orderBy = null,
+                 int? limit = null}) {
         var query = Query();
         var format = ResponseFormat();
         if (orderBy != null && !isDefault(orderBy)) {

--- a/client/lib/src/target_builder.dart
+++ b/client/lib/src/target_builder.dart
@@ -31,8 +31,8 @@ import 'package:spine_client/validate.dart';
 
 /// Creates a target which matches messages with the given IDs and field filters.
 Target target(Type type,
-              {Iterable<Object> ids,
-               Iterable<CompositeFilter> fieldFilters}) {
+              {Iterable<Object>? ids = null,
+               Iterable<CompositeFilter>? fieldFilters = null}) {
     var target = Target();
     target.type = _typeUrl(type);
     var filters = TargetFilters();

--- a/client/lib/src/url.dart
+++ b/client/lib/src/url.dart
@@ -24,8 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import 'package:http/http.dart' as http;
-
 /// A link which points to a network resource.
 ///
 class Url {
@@ -46,6 +44,7 @@ class Url {
         return Url('$host/$path');
     }
 
+    /// `Uri` representation of this URL.
     Uri get asUri => Uri.parse(stringUrl);
 
     @override

--- a/client/lib/subscription.dart
+++ b/client/lib/subscription.dart
@@ -141,7 +141,7 @@ class EventSubscription<T extends GeneratedMessage> extends Subscription<Event> 
 
     /// A stream of typed event messages.
     Stream<T> get eventMessages => events
-        .map((event) => unpack(event.message));
+        .map((event) => unpack(event.message) as T);
 }
 
 Future<String> _nodePath(Future<FirebaseSubscription> subscription) =>
@@ -150,7 +150,6 @@ Future<String> _nodePath(Future<FirebaseSubscription> subscription) =>
 
 Stream<String> _nodePathStream(Future<String> futureValue) =>
     futureValue.asStream().asBroadcastStream();
-
 
 Stream<T> _checkBroadcast<T>(Stream<T> stream) {
     if (!stream.isBroadcast) {

--- a/client/lib/subscription.dart
+++ b/client/lib/subscription.dart
@@ -50,7 +50,10 @@ class Subscription<T extends GeneratedMessage> {
     Subscription._(this.subscription, Stream<T> itemAdded)
         : _itemAdded = _checkBroadcast(itemAdded),
           _closed = false {
-        subscription.catchError((e) => unsubscribe());
+        subscription.catchError((e) {
+            unsubscribe();
+            return pb.Subscription.getDefault();
+        });
     }
 
     /// Shows if this subscription is still active or already closed.

--- a/client/lib/unknown_type.dart
+++ b/client/lib/unknown_type.dart
@@ -40,10 +40,10 @@ class UnknownTypeError extends Error {
     /// Exactly one parameter should be passed to this constructor, a [typeUrl] or a [runtimeType].
     /// If none is passed, an `ArgumentError` is thrown.
     ///
-    UnknownTypeError({String typeUrl, Type runtimeType}) :
+    UnknownTypeError({String? typeUrl, Type? runtimeType}) :
         _message = _composeMessage(typeUrl, runtimeType);
 
-    static String _composeMessage(String typeUrl, Type runtimeType) {
+    static String _composeMessage(String? typeUrl, Type? runtimeType) {
         String type;
         if (typeUrl != null) {
             type = typeUrl;

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spine_client
 description: Dart-based library for client applications of Spine-based systems.
-version: 1.7.2
+version: 1.7.3
 homepage: https://spine.io
 
 environment:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -4,18 +4,18 @@ version: 1.7.2
 homepage: https://spine.io
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.13.0 <3.0.0'
 
 dependencies:
-  protobuf: ^1.0.0
-  http: ^0.12.0+2
-  uuid: ^2.0.2
-  firebase: ^5.0.4
-  fixnum: ^0.10.9
-  sprintf: ^4.0.2
-  optional: ^3.1.0
+  protobuf: ^2.0.0
+  http: ^0.13.3
+  uuid: ^3.0.4
+  firebase: ^9.0.1
+  fixnum: ^1.0.0
+  sprintf: ^6.0.0
+  optional: ^6.0.0-nullsafety.2
 
 dev_dependencies:
-  pedantic: ^1.7.0
-  test: ^1.6.0
-  dartdoc: ^0.30.2
+  pedantic: ^1.11.0
+  test: ^1.17.4
+  dartdoc: ^0.43.0

--- a/client/test/client_test.dart
+++ b/client/test/client_test.dart
@@ -39,7 +39,7 @@ void main() {
 
             const String NON_EXISTING_BACKEND = 'http://doesntexist.spine.io/';
 
-            Clients clients;
+            late Clients clients;
 
             setUp(() {
                 clients = Clients(NON_EXISTING_BACKEND,

--- a/client/test/target_builder_test.dart
+++ b/client/test/target_builder_test.dart
@@ -56,7 +56,7 @@ void main() {
         });
 
         test('not allow generic IDs', () {
-            var ids = [StringBuffer().writeln('this is not allowed')];
+            var ids = [StringBuffer()];
             expect(() => target(Empty, ids: ids), throwsA(isA<ArgumentError>()));
         });
     });

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -30,17 +30,16 @@ import com.google.protobuf.gradle.id
 import com.google.protobuf.gradle.plugins
 import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.remove
-import io.spine.internal.gradle.Scripts
-import io.spine.internal.dependency.Protobuf
+import io.spine.gradle.internal.Deps
 
 plugins {
     dart
-    id("io.spine.mc-dart")
+    id("io.spine.tools.proto-dart-plugin")
 }
 
 apply {
-    from(Scripts.dartBuildTasks(project))
-    from(Scripts.pubPublishTasks(project))
+    from(Deps.scripts.dartBuildTasks(project))
+    from(Deps.scripts.pubPublishTasks(project))
 }
 
 val spineBaseVersion: String by extra
@@ -48,8 +47,7 @@ val spineBaseVersion: String by extra
 dependencies {
     protobuf("io.spine:spine-base:$spineBaseVersion")
     protobuf("io.spine.tools:spine-tool-base:$spineBaseVersion")
-    Protobuf.libs.forEach { protobuf(it) }
-}
+    Deps.build.protobuf.forEach { protobuf(it) }}
 
 tasks["testDart"].enabled = false
 

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -35,7 +35,7 @@ import io.spine.internal.dependency.Protobuf
 
 plugins {
     dart
-    id("io.spine.tools.proto-dart-plugin")
+    id("io.spine.mc-dart")
 }
 
 apply {

--- a/codegen/lib/dart_code_gen.dart
+++ b/codegen/lib/dart_code_gen.dart
@@ -56,7 +56,7 @@ String generate(Properties properties) {
               ..add(knownTypes.generateClass())
               ..add(knownTypes.generateAccessor())
     );
-    var emitter = DartEmitter(Allocator.simplePrefixing());
+    var emitter = DartEmitter(allocator: Allocator.simplePrefixing(), useNullSafetySyntax: true);
     var formatter = DartFormatter();
     return formatter.format(code.accept(emitter).toString());
 }

--- a/codegen/lib/src/constraint_violation.dart
+++ b/codegen/lib/src/constraint_violation.dart
@@ -74,26 +74,28 @@ createViolationFactory(String standardPackage) {
             ..type = listOfStrings
             ..name = fieldPath
         );
-        var anyType = refer('Any', protoAnyImport(standardPackage));
         var actualValueParam = Parameter((b) => b
             ..named = true
-            ..type = anyType
+            ..type = refer('Any?', protoAnyImport(standardPackage))
             ..name = actualValueArg
+            ..defaultTo = literalNull.code
         );
         var listOfViolations = TypeReference((b) => b
             ..symbol = 'List'
             ..types.add(violationTypeRef(standardPackage))
         );
+        var constList = Code('const []');
         var childConstraintsParam = Parameter((b) => b
             ..named = true
             ..type = listOfViolations
             ..name = childConstraintsArg
+            ..defaultTo = constList
         );
         var formatParamsParam = Parameter((b) => b
             ..named = true
             ..name = paramsArg
             ..type = listOfStrings
-            ..defaultTo = Code('const []')
+            ..defaultTo = constList
         );
         b.name = _violation;
         b.requiredParameters
@@ -106,6 +108,7 @@ createViolationFactory(String standardPackage) {
             ..add(formatParamsParam);
         var path = 'path';
         var type = violationTypeRef(standardPackage);
+        var anyType = refer('Any', protoAnyImport(standardPackage));
         b..returns = type
          ..body = Block.of(<Expression>[
              actualValueRef.assign(actualValueRef.notEqualTo(literalNull).conditional(

--- a/codegen/lib/src/noop_validator_factory.dart
+++ b/codegen/lib/src/noop_validator_factory.dart
@@ -24,32 +24,25 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import 'package:http/http.dart' as http;
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_code_gen/spine/options.pb.dart';
+import 'package:dart_code_gen/src/constraint_violation.dart';
+import 'package:dart_code_gen/src/field_validator_factory.dart';
+import 'package:dart_code_gen/src/type.dart';
+import 'package:dart_code_gen/src/validator_factory.dart';
 
-/// A link which points to a network resource.
+import 'field_validator_factory.dart';
+import 'validator_factory.dart';
+
+const String _validateLib = 'package:spine_client/validate.dart';
+
+/// A [FieldValidatorFactory] for fields which do not need validation.
 ///
-class Url {
+class NoOpValidatorFactory extends SingularFieldValidatorFactory {
 
-    /// String representation of this URL.
-    final String stringUrl;
-
-    Url(this.stringUrl);
-
-    /// Concatenates a URL from the given [host] and [path].
-    static Url from(String host, String path) {
-        if (host.endsWith('/')) {
-            host = host.substring(0, host.length - 1);
-        }
-        if (path.startsWith('/')) {
-            path = path.substring(1);
-        }
-        return Url('$host/$path');
-    }
-
-    Uri get asUri => Uri.parse(stringUrl);
+    NoOpValidatorFactory(ValidatorFactory validatorFactory, FieldDeclaration field)
+        : super(validatorFactory, field);
 
     @override
-    String toString() {
-        return stringUrl;
-    }
+    Iterable<Rule> rules() => [];
 }

--- a/codegen/lib/src/number_validator_factory.dart
+++ b/codegen/lib/src/number_validator_factory.dart
@@ -42,7 +42,7 @@ const _defaultMaxFormat = 'The number must be less than %s%s.';
 ///
 /// Supports options `(min)`, `(max)`, and `(range)`.
 ///
-class NumberValidatorFactory<N extends num> extends SingularFieldValidatorFactory {
+abstract class NumberValidatorFactory<N extends num> extends SingularFieldValidatorFactory {
     
     final String _wrapperType;
 
@@ -53,7 +53,7 @@ class NumberValidatorFactory<N extends num> extends SingularFieldValidatorFactor
 
     N _parse(String value) => _doParse(value.trim());
 
-    N _doParse(String value) => null;
+    N _doParse(String value);
     
     @override
     Iterable<Rule> rules() {
@@ -121,10 +121,10 @@ class NumberValidatorFactory<N extends num> extends SingularFieldValidatorFactor
             throw ArgumentError('Malformed range: `$rangeNotation`. '
                                 'See doc of (range) for the proper format.');
         }
-        var startOpen = match.group(1) == '(';
-        var start = _parse(match.group(2));
-        var end = _parse(match.group(3));
-        var endOpen = match.group(4) == ')';
+        var startOpen = match.group(1)! == '(';
+        var start = _parse(match.group(2)!);
+        var end = _parse(match.group(3)!);
+        var endOpen = match.group(4)! == ')';
 
         var minRule = _constructMinRule(start, startOpen, _defaultMinFormat);
         var maxRule = _constructMaxRule(end, endOpen, _defaultMaxFormat);

--- a/codegen/lib/src/required_field_validation_factory.dart
+++ b/codegen/lib/src/required_field_validation_factory.dart
@@ -56,7 +56,7 @@ class RequiredFieldValidatorFactory {
 
     Code generate() {
         if (_combinations.length == 0) {
-            return null;
+            return Code("");
         }
         var violationInit = violationRef.call([literalString('Required fields must be set.'),
                                                literalString(_validator.fullTypeName),

--- a/codegen/lib/src/type.dart
+++ b/codegen/lib/src/type.dart
@@ -83,7 +83,7 @@ class MessageType {
     /// For example, `type.spine.io/spine.net.Uri.Protocol`
     ///
     String get typeUrl {
-        var prefix = file.options.getExtension(Options.typeUrlPrefix) as String ?? '';
+        var prefix = file.options.getExtension(Options.typeUrlPrefix) as String? ?? '';
         prefix = prefix.isNotEmpty ? prefix : _standardTypeUrlPrefix;
         return "$prefix/$fullName";
     }

--- a/codegen/lib/src/validator_factory.dart
+++ b/codegen/lib/src/validator_factory.dart
@@ -145,12 +145,8 @@ class ValidatorFactory {
     ///
     Code _createFieldValidator(FieldDeclaration field) {
         var factory = FieldValidatorFactory.forField(field, this);
-        if (factory != null) {
-            var fieldValue = accessField(field);
-            return factory.createFieldValidator(fieldValue);
-        } else {
-            return null;
-        }
+        var fieldValue = accessField(field);
+        return factory.createFieldValidator(fieldValue);
     }
 
     Expression accessField(FieldDeclaration field) => _typedMessage.property(field.escapedDartName);

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -4,19 +4,19 @@ version: 1.7.2
 homepage: https://spine.io
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.13.0 <3.0.0'
 
 dependencies:
-  args: 1.5.2
-  protobuf: ^1.0.0
-  fixnum: ^0.10.9
-  code_builder: ^3.2.0
-  dart_style: 1.3.1
-  optional: ^3.1.0
+  args: 2.1.0
+  protobuf: ^2.0.0
+  fixnum: ^1.0.0
+  code_builder: ^4.0.0
+  dart_style: ^2.0.1
+  optional: ^6.0.0-nullsafety.2
 
 dev_dependencies:
-  pedantic: ^1.8.0
-  test: ^1.6.0
+  pedantic: ^1.11.0
+  test: ^1.17.4
 
 executables:
   dart_code_gen: main

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_code_gen
 description: A command-line tool which generates Dart code for Protobuf type registries.
-version: 1.7.2
+version: 1.7.3
 homepage: https://spine.io
 
 environment:

--- a/integration-tests/client-test/build.gradle.kts
+++ b/integration-tests/client-test/build.gradle.kts
@@ -31,17 +31,16 @@ import com.google.protobuf.gradle.plugins
 import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.remove
 import com.google.protobuf.gradle.testProtobuf
-import io.spine.internal.gradle.Scripts
+import io.spine.gradle.internal.Deps
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
     codegen
     dart
-    id("io.spine.mc-dart")
-}
+    id("io.spine.tools.proto-dart-plugin")}
 
 apply {
-    from(Scripts.dartBuildTasks(project))
+    from(Deps.scripts.dartBuildTasks(project))
 }
 
 dependencies {

--- a/integration-tests/client-test/build.gradle.kts
+++ b/integration-tests/client-test/build.gradle.kts
@@ -37,7 +37,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 plugins {
     codegen
     dart
-    id("io.spine.tools.proto-dart-plugin")
+    id("io.spine.mc-dart")
 }
 
 apply {

--- a/integration-tests/client-test/build.gradle.kts
+++ b/integration-tests/client-test/build.gradle.kts
@@ -31,7 +31,7 @@ import com.google.protobuf.gradle.plugins
 import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.remove
 import com.google.protobuf.gradle.testProtobuf
-import io.spine.gradle.internal.Deps
+import io.spine.internal.gradle.Scripts
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
@@ -41,9 +41,8 @@ plugins {
 }
 
 apply {
-    from(Deps.scripts.dartBuildTasks(project))
+    from(Scripts.dartBuildTasks(project))
 }
-
 
 dependencies {
     testProtobuf(project(":test-app"))

--- a/integration-tests/client-test/integration-test/client_test.dart
+++ b/integration-tests/client-test/integration-test/client_test.dart
@@ -47,9 +47,10 @@ import 'types.dart' as testTypes;
 void main() {
 
     group('Client should', () {
-        Clients clients;
-        FirebaseClient firebaseClient;
-        UserId actor;
+
+        late Clients clients;
+        late FirebaseClient firebaseClient;
+        late UserId actor;
 
         setUp(() {
             var database = FirebaseApp().database;

--- a/integration-tests/client-test/pubspec.yaml
+++ b/integration-tests/client-test/pubspec.yaml
@@ -3,12 +3,12 @@ description: Tests for package `spine_client`.
 publish_to: none
 
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: '>=2.13.0 <3.0.0'
 
 dependencies:
   spine_client:
     path: ../../client
 
 dev_dependencies:
-  pedantic: ^1.7.0
-  test: ^1.6.0
+  pedantic: ^1.11.0
+  test: ^1.17.4

--- a/integration-tests/test-app/build.gradle.kts
+++ b/integration-tests/test-app/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.spine.internal.gradle.Scripts
-
 /*
  * Copyright 2021, TeamDev. All rights reserved.
  *
@@ -25,6 +23,8 @@ import io.spine.internal.gradle.Scripts
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+import io.spine.internal.gradle.Scripts
 
 buildscript {
 
@@ -77,13 +77,18 @@ sourceSets {
     }
 }
 
+val spineCoreVersion: String by extra
 val spineWebVersion: String by extra
 
 dependencies {
+    implementation("io.spine:spine-server:$spineCoreVersion")
     implementation("io.spine.gcloud:spine-firebase-web:$spineWebVersion")
 }
 
-configurations.all { resolutionStrategy { force("com.google.code.gson:gson:2.7") } }
+configurations.all { resolutionStrategy {
+    force("com.google.code.gson:gson:2.7")
+    force("io.spine:spine-server:$spineCoreVersion")
+}}
 
 gretty {
     contextPath = "/"

--- a/integration-tests/test-app/build.gradle.kts
+++ b/integration-tests/test-app/build.gradle.kts
@@ -1,3 +1,5 @@
+import io.spine.internal.gradle.Scripts
+
 /*
  * Copyright 2021, TeamDev. All rights reserved.
  *
@@ -28,6 +30,12 @@ buildscript {
 
     io.spine.gradle.internal.DependencyResolution.defaultRepositories(repositories)
 
+    repositories {
+        repositories.maven {
+            url = uri(io.spine.gradle.internal.Repos.spineSnapshots)
+        }
+    }
+
     val spineBaseVersion: String by extra
 
     dependencies {
@@ -43,7 +51,7 @@ plugins {
 
 apply {
     plugin("io.spine.tools.spine-model-compiler")
-    from("$rootDir/config/gradle/model-compiler.gradle")
+    from(Scripts.modelCompiler(project))
 }
 
 val sourcesRootDir = "$projectDir/src"

--- a/integration-tests/test-app/build.gradle.kts
+++ b/integration-tests/test-app/build.gradle.kts
@@ -77,18 +77,13 @@ sourceSets {
     }
 }
 
-val spineCoreVersion: String by extra
 val spineWebVersion: String by extra
 
 dependencies {
-    implementation("io.spine:spine-server:$spineCoreVersion")
     implementation("io.spine.gcloud:spine-firebase-web:$spineWebVersion")
 }
 
-configurations.all { resolutionStrategy {
-    force("com.google.code.gson:gson:2.7")
-    force("io.spine:spine-server:$spineCoreVersion")
-}}
+configurations.all { resolutionStrategy { force("com.google.code.gson:gson:2.7") } }
 
 gretty {
     contextPath = "/"

--- a/integration-tests/test-app/build.gradle.kts
+++ b/integration-tests/test-app/build.gradle.kts
@@ -45,7 +45,7 @@ buildscript {
 
 plugins {
     java
-    id("org.gretty") version ("3.0.3")
+    id("org.gretty") version ("3.0.4")
     id("com.github.psxpaul.execfork") version ("0.1.13")
 }
 
@@ -96,7 +96,7 @@ gretty {
     debugPort = 5005
     isDebugSuspend = true
     jvmArgs = listOf("-Dio.spine.tests=true", "-Xverify:none")
-    servletContainer = "jetty9"
+    servletContainer = "jetty9.4"
     managedClassReload = false
     fastReload = false
 }

--- a/integration-tests/test-app/build.gradle.kts
+++ b/integration-tests/test-app/build.gradle.kts
@@ -39,7 +39,7 @@ buildscript {
     val spineBaseVersion: String by extra
 
     dependencies {
-        classpath("io.spine.tools:spine-model-compiler:$spineBaseVersion")
+        classpath("io.spine.tools:spine-mc-java:$spineBaseVersion")
     }
 }
 
@@ -50,7 +50,7 @@ plugins {
 }
 
 apply {
-    plugin("io.spine.tools.spine-model-compiler")
+    plugin("io.spine.mc-java")
     from(Scripts.modelCompiler(project))
 }
 

--- a/integration-tests/test-app/build.gradle.kts
+++ b/integration-tests/test-app/build.gradle.kts
@@ -24,22 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.spine.internal.gradle.Scripts
-
 buildscript {
 
     io.spine.gradle.internal.DependencyResolution.defaultRepositories(repositories)
 
-    repositories {
-        repositories.maven {
-            url = uri(io.spine.gradle.internal.Repos.spineSnapshots)
-        }
-    }
-
     val spineBaseVersion: String by extra
 
     dependencies {
-        classpath("io.spine.tools:spine-mc-java:$spineBaseVersion")
+        classpath("io.spine.tools:spine-model-compiler:$spineBaseVersion")
     }
 }
 
@@ -50,8 +42,8 @@ plugins {
 }
 
 apply {
-    plugin("io.spine.mc-java")
-    from(Scripts.modelCompiler(project))
+    plugin("io.spine.tools.spine-model-compiler")
+    from("$rootDir/config/gradle/model-compiler.gradle")
 }
 
 val sourcesRootDir = "$projectDir/src"

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectProgressProjection.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectProgressProjection.java
@@ -28,7 +28,6 @@ package io.spine.web.test.given;
 
 import io.spine.core.Subscribe;
 import io.spine.server.projection.Projection;
-import io.spine.server.entity.storage.Column;
 
 import static io.spine.web.test.given.Status.COMPLETED;
 import static io.spine.web.test.given.Status.IN_PROGRESS;

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectProgressProjection.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectProgressProjection.java
@@ -38,7 +38,7 @@ import static io.spine.web.test.given.Status.NOT_STARTED;
  *
  * <p>Calculates the amount of the completed and uncompleted tasks. Upon completion of all tasks,
  * switches the project progress status to the {@code COMPLETED}. Current status is exposed as
- * {@linkplain Column column} allowing filtering of completed and uncompleted progresses.
+ * a column allowing filtering of completed and uncompleted progresses.
  */
 public class ProjectProgressProjection
         extends Projection<ProjectId, ProjectProgress, ProjectProgress.Builder> {

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectRepository.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectRepository.java
@@ -31,5 +31,5 @@ import io.spine.server.aggregate.AggregateRepository;
 /**
  * A repository for the project aggregates.
  */
-class ProjectRepository extends AggregateRepository<ProjectId, ProjectAggregate, Project> {
+class ProjectRepository extends AggregateRepository<ProjectId, ProjectAggregate> {
 }

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectRepository.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectRepository.java
@@ -31,5 +31,5 @@ import io.spine.server.aggregate.AggregateRepository;
 /**
  * A repository for the project aggregates.
  */
-class ProjectRepository extends AggregateRepository<ProjectId, ProjectAggregate> {
+class ProjectRepository extends AggregateRepository<ProjectId, ProjectAggregate, Project> {
 }

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/TaskRepository.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/TaskRepository.java
@@ -31,5 +31,5 @@ import io.spine.server.aggregate.AggregateRepository;
 /**
  * A repository for the task aggregates.
  */
-class TaskRepository extends AggregateRepository<TaskId, TaskAggregate> {
+class TaskRepository extends AggregateRepository<TaskId, TaskAggregate, Task> {
 }

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/TaskRepository.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/TaskRepository.java
@@ -31,5 +31,5 @@ import io.spine.server.aggregate.AggregateRepository;
 /**
  * A repository for the task aggregates.
  */
-class TaskRepository extends AggregateRepository<TaskId, TaskAggregate, Task> {
+class TaskRepository extends AggregateRepository<TaskId, TaskAggregate> {
 }

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/UserTasksProjection.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/UserTasksProjection.java
@@ -28,7 +28,6 @@ package io.spine.web.test.given;
 
 import io.spine.core.Subscribe;
 import io.spine.core.UserId;
-import io.spine.server.entity.storage.Column;
 import io.spine.server.projection.Projection;
 
 import java.util.List;

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/UserTasksProjection.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/UserTasksProjection.java
@@ -35,8 +35,8 @@ import java.util.List;
 /**
  * A projection representing a user and a list of {@link TaskId tasks} assigned to him.
  *
- * <p>Assigned tasks count and indication of several tasks assigned are exposed as
- * {@linkplain Column columns} allowing ordering and filtering when user tasks are queried.
+ * <p>Assigned tasks count and indication of several tasks assigned are exposed as columns allowing
+ * ordering and filtering when user tasks are queried.
  */
 public class UserTasksProjection
         extends Projection<UserId, UserTasks, UserTasks.Builder> {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -30,5 +30,6 @@
  */
 
 val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.29")
+val spineCoreVersion: String by extra("2.0.0-SNAPSHOT.21")
 val spineWebVersion: String by extra("1.7.1")
 val versionToPublish: String by extra("1.7.1")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,6 +29,6 @@
  * already in the root directory.
  */
 
-val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.21")
+val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.29")
 val spineWebVersion: String by extra("1.7.1")
 val versionToPublish: String by extra("1.7.1")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,6 +29,6 @@
  * already in the root directory.
  */
 
-val spineBaseVersion: String by extra("1.7.4")
+val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.21")
 val spineWebVersion: String by extra("1.7.1")
 val versionToPublish: String by extra("1.7.1")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,7 +29,6 @@
  * already in the root directory.
  */
 
-val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.29")
-val spineCoreVersion: String by extra("2.0.0-SNAPSHOT.21")
+val spineBaseVersion: String by extra("1.7.4")
 val spineWebVersion: String by extra("1.7.1")
 val versionToPublish: String by extra("1.7.1")


### PR DESCRIPTION
In this PR we introduce null safety API our the Dart libraries.

All the dependencies, except `dartdoc`, which is a dev dependency and does not affect the lib users, now support null safety.

The version is promoted to `1.7.3`.
Dart version now must be `2.13` or higher.