### PR TITLE
Allow to cancel event subscriptions

### DIFF
--- a/client/lib/client.dart
+++ b/client/lib/client.dart
@@ -38,7 +38,6 @@ import 'package:spine_client/spine/client/subscription.pb.dart' as pbSubscriptio
 import 'package:spine_client/spine/core/ack.pb.dart';
 import 'package:spine_client/spine/core/command.pb.dart';
 import 'package:spine_client/spine/core/diagnostics.pb.dart';
-import 'package:spine_client/spine/core/event.pb.dart';
 import 'package:spine_client/spine/core/tenant_id.pb.dart';
 import 'package:spine_client/spine/core/user_id.pb.dart';
 import 'package:spine_client/spine/time/time.pb.dart';
@@ -403,28 +402,7 @@ class CommandRequest<M extends GeneratedMessage> {
     /// Events down the line, i.e. events produced as the result of other messages which where
     /// produced as the result of this command, do not match this subscription.
     ///
-    /// Returns a broadcast stream of event messages.
-    ///
-    /// See `CommandRequest.observeEventsWithContexts(..)` to receive metadata, as well as the event
-    /// messages.
-    ///
-    ///
-    Stream<E> observeEvents<E extends GeneratedMessage>() =>
-        _observeEvents<E>().eventMessages;
-
-    /// Creates an event subscription for events produced as a direct result of this command.
-    ///
-    /// Events down the line, i.e. events produced as the result of other messages which where
-    /// produced as the result of this command, do not match this subscription.
-    ///
-    /// Returns a broadcast stream of events with their metadata.
-    ///
-    /// See `CommandRequest.observeEvents(..)` to unpacked event messages.
-    ///
-    Stream<Event> observeEventsWithContexts<E extends GeneratedMessage>() =>
-        _observeEvents<E>().events;
-
-    EventSubscription<E> _observeEvents<E extends GeneratedMessage>() {
+    EventSubscription<E> observeEvents<E extends GeneratedMessage>() {
         var subscription = _client.subscribeToEvents<E>()
             .where(all([eq('context.past_message', _commandAsOrigin())]))
             .post();

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spine_client
 description: Dart-based library for client applications of Spine-based systems.
-version: 1.7.3
+version: 1.7.4
 homepage: https://spine.io
 
 environment:
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   pedantic: ^1.11.0
   test: ^1.17.4
-  dartdoc: ^0.43.0
+  dartdoc: ^1.0.0

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,13 +1,13 @@
 name: dart_code_gen
 description: A command-line tool which generates Dart code for Protobuf type registries.
-version: 1.7.3
+version: 1.7.4
 homepage: https://spine.io
 
 environment:
   sdk: '>=2.13.0 <3.0.0'
 
 dependencies:
-  args: 2.1.0
+  args: ^2.1.0
   protobuf: ^2.0.0
   fixnum: ^1.0.0
   code_builder: ^4.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,31 +1,5 @@
-#
-# Copyright 2021, TeamDev. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Redistribution and use in source and/or binary forms, with or without
-# modification, must retain the above copyright notice and the following
-# disclaimer.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
In this PR we expose the `EventSubscription` instead of `Stream<EventMessage>` when a user subscribes to an event as a command result.

In other places where users subscribe to things, we already expose an `EventSubscription` or a `StateSubscription`.

The `EventSubscription` has API for cancelling itself, unlike a Dart `Stream`.

This PR fixes #30.