### PR TITLE
Async subscriptions

### DIFF
--- a/client/lib/client.dart
+++ b/client/lib/client.dart
@@ -403,6 +403,10 @@ class CommandRequest<M extends GeneratedMessage> {
     /// Events down the line, i.e. events produced as the result of other messages which where
     /// produced as the result of this command, do not match this subscription.
     ///
+    /// When the resulting future completes, the subscription is guaranteed to be created.
+    /// Also, when the future created in `post(..)` completes, the all subscriptions created within
+    /// the same `CommandRequest` are guaranteed to have completed.
+    ///
     Future<EventSubscription<E>> observeEvents<E extends GeneratedMessage>() {
         var subscription = _client.subscribeToEvents<E>()
             .where(all([eq('context.past_message', _commandAsOrigin())]))
@@ -424,6 +428,9 @@ class CommandRequest<M extends GeneratedMessage> {
     ///
     /// Fails if there are no event subscriptions to monitor the command execution. If this is
     /// the desired behaviour, use `CommandRequest.postAndForget(..)`.
+    ///
+    /// When the command is sent, the event subscriptions created within this request
+    /// are guaranteed to be active.
     ///
     /// Returns a future which completes when the request is sent. If there was a network problem,
     /// the future, completes with an error.
@@ -606,6 +613,9 @@ class StateSubscriptionRequest<M extends GeneratedMessage> {
 
     /// Asynchronously sends this request to the server.
     ///
+    /// The subscription is guaranteed to have been created on server when the resulting future
+    /// completes.
+    ///
     Future<StateSubscription<M>> post() {
         var topic = _client._requests.topic().withFilters(_type, ids: _ids, filters: _filters);
         var builderInfo = theKnownTypes.findBuilderInfo(theKnownTypes.typeUrlFrom(_type))!;
@@ -637,6 +647,9 @@ class EventSubscriptionRequest<M extends GeneratedMessage> {
     }
 
     /// Asynchronously sends this request to the server.
+    ///
+    /// The subscription is guaranteed to have been created on server when the resulting future
+    /// completes.
     ///
     Future<EventSubscription<M>> post() {
         var topic = _client._requests.topic().withFilters(_type, filters: _filers);

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spine_client
 description: Dart-based library for client applications of Spine-based systems.
-version: 1.7.4
+version: 1.7.5
 homepage: https://spine.io
 
 environment:

--- a/client/test/client_test.dart
+++ b/client/test/client_test.dart
@@ -62,19 +62,17 @@ void main() {
             });
 
             test('when subscribing to updates', () async {
-                var result = clients.asGuest()
-                                    .subscribeTo<Project>()
-                                    .post();
-                var stream = result.itemAdded;
-                expect(() async => await stream.first, throwsA(isNotNull));
+                var subscription = clients.asGuest()
+                                          .subscribeTo<Project>()
+                                          .post();
+                expect(() async => await subscription, throwsA(isNotNull));
             });
 
             test('when subscribing to event updates', () async {
-                var result = clients.asGuest()
-                    .subscribeToEvents<ProjectCreated>()
-                    .post();
-                var stream = result.eventMessages;
-                expect(() async => await stream.first, throwsA(isNotNull));
+                var subscription = clients.asGuest()
+                                          .subscribeToEvents<ProjectCreated>()
+                                          .post();
+                expect(() async => await subscription, throwsA(isNotNull));
             });
         });
     });

--- a/client/test/filter_test.dart
+++ b/client/test/filter_test.dart
@@ -40,48 +40,48 @@ void main() {
     group('Client should create', () {
 
         test('`equals` filters', () {
-            var filter = eq(fieldPath, 42);
+            var filter = eq(fieldPath, 42).filter;
             expect(filter.operator, equals(Filter_Operator.EQUAL));
             expect(filter.fieldPath.fieldName, containsAllInOrder([firstElement, secondElement]));
             expect(unpack(filter.value), isA<Int32Value>());
         });
 
         test('`greater than` filters', () {
-            var filter = gt(fieldPath, 2.71);
+            var filter = gt(fieldPath, 2.71).filter;
             expect(filter.operator, equals(Filter_Operator.GREATER_THAN));
             expect(filter.fieldPath.fieldName, containsAllInOrder([firstElement, secondElement]));
             expect(unpack(filter.value), isA<DoubleValue>());
         });
 
         test('`less than` filters', () {
-            var filter = lt(fieldPath, 3.14);
+            var filter = lt(fieldPath, 3.14).filter;
             expect(filter.operator, equals(Filter_Operator.LESS_THAN));
             expect(filter.fieldPath.fieldName, containsAllInOrder([firstElement, secondElement]));
             expect(unpack(filter.value), isA<DoubleValue>());
         });
 
         test('`greater or equals` filters', () {
-            var filter = ge(fieldPath, now());
+            var filter = ge(fieldPath, now()).filter;
             expect(filter.operator, equals(Filter_Operator.GREATER_OR_EQUAL));
             expect(filter.fieldPath.fieldName, containsAllInOrder([firstElement, secondElement]));
             expect(unpack(filter.value), isA<Timestamp>());
         });
 
         test('`less or equals` filters', () {
-            var filter = le(fieldPath, now());
+            var filter = le(fieldPath, now()).filter;
             expect(filter.operator, equals(Filter_Operator.LESS_OR_EQUAL));
             expect(filter.fieldPath.fieldName, containsAllInOrder([firstElement, secondElement]));
             expect(unpack(filter.value), isA<Timestamp>());
         });
 
         test('`all` filters', () {
-            var filter = all([ge(fieldPath, 0), le(fieldPath, 1)]);
+            var filter = all([ge(fieldPath, 0), le(fieldPath, 1)]).filter;
             expect(filter.operator, equals(CompositeFilter_CompositeOperator.ALL));
             expect(filter.filter.length, equals(2));
         });
 
         test('`either` filters', () {
-            var filter = either([ge(fieldPath, 100), le(fieldPath, -1), eq(fieldPath, 42)]);
+            var filter = either([ge(fieldPath, 100), le(fieldPath, -1), eq(fieldPath, 42)]).filter;
             expect(filter.operator, equals(CompositeFilter_CompositeOperator.EITHER));
             expect(filter.filter.length, equals(3));
         });

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_code_gen
 description: A command-line tool which generates Dart code for Protobuf type registries.
-version: 1.7.4
+version: 1.7.5
 homepage: https://spine.io
 
 environment:

--- a/integration-tests/client-test/integration-test/client_test.dart
+++ b/integration-tests/client-test/integration-test/client_test.dart
@@ -108,15 +108,18 @@ void main() {
             var client = clients.onBehalfOf(actor);
             var request = client.command(cmd);
             var futureSubscription = request.observeEvents<TaskCreated>();
+            var taskCreated = futureSubscription
+                .then((s) => s.eventMessages.first);
             await request.post();
 
-            // Subscription must be complete when `post` is complete.
-            var subscription = await futureSubscription;
-            var event = await subscription.eventMessages.first;
+            var event = await taskCreated;
             expect(event.id, equals(taskId));
 
-            expect(subscription.closed, equals(false));
-            subscription.unsubscribe();
+            futureSubscription.then((s) {
+                expect(s.closed, equals(false));
+                s.unsubscribe();
+            });
+            var subscription = await futureSubscription;
             expect(subscription.closed, equals(true));
         });
 

--- a/integration-tests/client-test/integration-test/client_test.dart
+++ b/integration-tests/client-test/integration-test/client_test.dart
@@ -84,9 +84,9 @@ void main() {
                 ..description = 'Firebase query test';
             var client = clients.onBehalfOf(actor);
             var request = client.command(cmd);
-            var stateSubscription = client.subscribeTo<Task>()
-                                          .whereIdIn([taskId])
-                                          .post();
+            var stateSubscription = await client.subscribeTo<Task>()
+                                                .whereIdIn([taskId])
+                                                .post();
             request.postAndForget();
             await stateSubscription.itemAdded.first;
             await _sleep();
@@ -107,10 +107,12 @@ void main() {
                 ..description = 'Firebase event subscription test';
             var client = clients.onBehalfOf(actor);
             var request = client.command(cmd);
-            var subscription = request.observeEvents<TaskCreated>();
-            request.post();
+            var futureSubscription = request.observeEvents<TaskCreated>();
+            await request.post();
+
+            // Subscription must be complete when `post` is complete.
+            var subscription = await futureSubscription;
             var event = await subscription.eventMessages.first;
-            await _sleep();
             expect(event.id, equals(taskId));
 
             expect(subscription.closed, equals(false));
@@ -133,9 +135,9 @@ void main() {
                 ..description = 'direct query test';
 
             var client = clients.onBehalfOf(actor);
-            var newTasks = client.subscribeTo<Task>()
-                                 .whereIdIn([taskId])
-                                 .post();
+            var newTasks = await client.subscribeTo<Task>()
+                                       .whereIdIn([taskId])
+                                       .post();
             client.command(cmd)
                   .postAndForget();
             // Make sure command is processed...
@@ -155,9 +157,7 @@ void main() {
 
         test('subscribe to entity changes', () async {
             var client = clients.onBehalfOf(actor);
-            StateSubscription<Task> entitySubscription =
-                    client.subscribeTo<Task>()
-                          .post();
+            StateSubscription<Task> entitySubscription = await client.subscribeTo<Task>().post();
             Stream<Task> itemAdded = entitySubscription.itemAdded;
             var taskId = TaskId()
                 ..value = newUuid();
@@ -169,7 +169,7 @@ void main() {
             var taskCreatedEvents = createTaskRequest.observeEvents<TaskCreated>();
             createTaskRequest.post();
 
-            var newTaskEvent = await taskCreatedEvents.eventMessages.first;
+            var newTaskEvent = await taskCreatedEvents.then((s) => s.eventMessages.first);
             expect(newTaskEvent.id, equals(taskId));
             var newTask = await itemAdded.first;
             expect(newTask.name, equals(createTaskCmd.name));
@@ -187,9 +187,9 @@ void main() {
         });
 
         test('query entities by column values', () async {
-            var newTasks = clients.asGuest()
-                                  .subscribeTo<UserTasks>()
-                                  .post();
+            var newTasks = await clients.asGuest()
+                                        .subscribeTo<UserTasks>()
+                                        .post();
             var client = clients.onBehalfOf(actor);
             var olderTaskId = TaskId()..value = newUuid();
             client.command(CreateTask()
@@ -219,9 +219,9 @@ void main() {
         });
 
         test('query entities with order and limit', () async {
-            var newProjections = clients.asGuest()
-                .subscribeTo<UserTasks>()
-                .post();
+            var newProjections = await clients.asGuest()
+                                              .subscribeTo<UserTasks>()
+                                              .post();
             var client = clients.onBehalfOf(actor);
             client.command(CreateTask()
                 ..id = (TaskId()..value = newUuid())
@@ -255,9 +255,9 @@ void main() {
         });
 
         test('query entities by enum column values', () async {
-            var projectProgress = clients.asGuest()
-                .subscribeTo<ProjectProgress>()
-                .post();
+            var projectProgress = await clients.asGuest()
+                                               .subscribeTo<ProjectProgress>()
+                                               .post();
             var client = clients.onBehalfOf(actor);
             var completedProject = ProjectId()..value = newUuid();
             client.command(CreateProject()


### PR DESCRIPTION
In this PR we expose the asynchronous nature of the event and state subscriptions to the user.
Previously, the user received an `EventSubscription<..>`/`StateSubscription<..>` right away after calling `post(..)`. This, however, does not reflect the reality of subscriptions on the server being created eventually. The returned object used to hide a `Future` which ought to complete when the subscription reaches the server.

Now, the `post(..)` and similar methods return not a subscription, but a `Future`. This should let the user know that the subscription is not yet "live".

This fixes #32.

Also, in this PR we add wrappers with a common interface for `FIlter` and `CompositeFilter`. This allows users to pass a single`Filter` into `where(..)`. Previously, the users had to wrap the filter into `all([..])` manually each time.

This fixes #31.