### PR TITLE
Release 1.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,14 @@
 **/generated/**
 
 # Gradle build files
-**/build/**
+# IMPORTANT: ignoring `/build/` folder in any form makes it impossible to publish
+# the `build/pub/..` contents due to the recently introduced `pub` tool regulations.
+**/build/descriptors
+**/build/extracted-include-protos
+**/build/extracted-protos
+**/build/libs
+**/build/resources
+**/build/tmp
 
 # Build files produced by the IDE
 **/out/**
@@ -94,7 +101,7 @@ hs_err_pid*
 # Files and directories created by pub
 .dart_tool/
 .packages
-pubspec.lock
+#pubspec.lock
 
 **/*.pb.dart
 **/*.pbenum.dart

--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,7 @@ hs_err_pid*
 # Files and directories created by pub
 .dart_tool/
 .packages
-#pubspec.lock
+pubspec.lock
 
 **/*.pb.dart
 **/*.pbenum.dart

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -4,8 +4,8 @@
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 
-# Conventional directory for build outputs
-build/
+# IMPORTANT: ignoring `/build/` folder in any form makes it impossible to publish
+# the `build/pub/..` contents due to the recently introduced `pub` tool regulations.
 
 # Directory created by dartdoc
 doc/api/

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -41,3 +41,20 @@
 ## 1.7.3
  This release introduces null-safe API, according to the new Dart null safety feature.
  The Dart language version is promoted to `2.13`.
+
+## 1.7.4
+
+ In this release, the subscription API has been improved. It is now possible to cancel the event 
+ subscriptions via `EventSubscription` type, which is now returned 
+ instead of `Stream<EventMessage>`.
+
+## 1.7.5
+ In this release, the asynchronous nature of the subscription API has been reflected in returning
+ `Future`s upon calling `post(..)`. This makes the flow more transparent for end-users, 
+ as previously `Future` instances were hidden deep inside the returned `EventSubscription` and
+ `StateSubscription` objects.
+
+## 1.8.0
+ This release is a compatibility package, issued in scope of Spine's `1.8.0` release. 
+ Additionally, the dependency onto `optional` package was upgraded from 
+ a pre-release `6.0.0-nullsafety.2` to `^6.0.0`.

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spine_client
 description: Dart-based library for client applications of Spine-based systems.
-version: 1.7.5
+version: 1.8.0
 homepage: https://spine.io
 
 environment:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   firebase: ^9.0.1
   fixnum: ^1.0.0
   sprintf: ^6.0.0
-  optional: ^6.0.0-nullsafety.2
+  optional: ^6.0.0
 
 dev_dependencies:
   pedantic: ^1.11.0

--- a/codegen/.gitignore
+++ b/codegen/.gitignore
@@ -4,8 +4,8 @@
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 
-# Conventional directory for build outputs
-build/
+# IMPORTANT: ignoring `/build/` folder in any form makes it impossible to publish
+# the `build/pub/..` contents due to the recently introduced `pub` tool regulations.
 
 # Directory created by dartdoc
 doc/api/

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_code_gen
 description: A command-line tool which generates Dart code for Protobuf type registries.
-version: 1.7.5
+version: 1.8.0
 homepage: https://spine.io
 
 environment:

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   fixnum: ^1.0.0
   code_builder: ^4.0.0
   dart_style: ^2.0.1
-  optional: ^6.0.0-nullsafety.2
+  optional: ^6.0.0
 
 dev_dependencies:
   pedantic: ^1.11.0

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,6 +29,6 @@
  * already in the root directory.
  */
 
-val spineBaseVersion: String by extra("1.7.4")
-val spineWebVersion: String by extra("1.7.1")
-val versionToPublish: String by extra("1.7.2-SNAPSHOT.1")
+val spineBaseVersion: String by extra("1.8.0")
+val spineWebVersion: String by extra("1.8.0")
+val versionToPublish: String by extra("1.8.0")


### PR DESCRIPTION
This changeset releases the version `1.8.0`.

The changes include:

* The `client/CHANGELOG.md` was updated by documenting the changes from three of the most recent releases.
* `optional` dependency has been upgraded from a pre-release version.
* `.gitignore` files were modified to exclude `**/build/pub` folders — as including those made it impossible to publish the packages via `pub` tool.