### PR TITLE
Release 1.8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,16 +98,21 @@ gcs-auth-key.json
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-# Files and directories created by pub
-.dart_tool/
-.packages
-pubspec.lock
 
-**/*.pb.dart
-**/*.pbenum.dart
-**/*.pbserver.dart
-**/*.pbjson.dart
-**/types.dart
-**/validators.dart
+# IMPORTANT: Any ignored `.dart` files produced by `pub` tool won't make their way to the final
+# package. Therefore, no files should be ignored.
+#
+# Files and directories created by pub:
+#
+#.dart_tool/
+#.packages
+#pubspec.lock
+#
+#**/*.pb.dart
+#**/*.pbenum.dart
+#**/*.pbserver.dart
+#**/*.pbjson.dart
+#**/types.dart
+#**/validators.dart
 
 **/spine-dev.json

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -58,3 +58,6 @@
  This release is a compatibility package, issued in scope of Spine's `1.8.0` release. 
  Additionally, the dependency onto `optional` package was upgraded from 
  a pre-release `6.0.0-nullsafety.2` to `^6.0.0`.
+
+## 1.8.1
+ This release fixes the previously broken `dart_code_gen:1.8.0`.

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spine_client
 description: Dart-based library for client applications of Spine-based systems.
-version: 1.8.0
+version: 1.8.1
 homepage: https://spine.io
 
 environment:

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_code_gen
 description: A command-line tool which generates Dart code for Protobuf type registries.
-version: 1.8.0
+version: 1.8.1
 homepage: https://spine.io
 
 environment:

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -31,4 +31,4 @@
 
 val spineBaseVersion: String by extra("1.8.0")
 val spineWebVersion: String by extra("1.8.0")
-val versionToPublish: String by extra("1.8.0")
+val versionToPublish: String by extra("1.8.1")


### PR DESCRIPTION
This changeset serves to re-publish the packages to `pub.dev` — as `dart_code_gen:1.8.0` was missing some of the files due to `.gitignore` settings.