### PR TITLE
Update copyright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Redistribution and use in source and/or binary forms, with or without
 # modification, must retain the above copyright notice and the following

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/checkstyle.gradle
+++ b/buildSrc/src/main/groovy/checkstyle.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/dart/build-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/build-tasks.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/dependencies.gradle
+++ b/buildSrc/src/main/groovy/dependencies.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/filter-internal-javadoc.gradle
+++ b/buildSrc/src/main/groovy/filter-internal-javadoc.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/generate-pom.gradle
+++ b/buildSrc/src/main/groovy/generate-pom.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/jacoco.gradle
+++ b/buildSrc/src/main/groovy/jacoco.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/javac-args.gradle
+++ b/buildSrc/src/main/groovy/javac-args.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/javadoc-options.gradle
+++ b/buildSrc/src/main/groovy/javadoc-options.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/js/build-tasks.gradle
+++ b/buildSrc/src/main/groovy/js/build-tasks.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/js/configure-proto.gradle
+++ b/buildSrc/src/main/groovy/js/configure-proto.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/js/npm-cli.gradle
+++ b/buildSrc/src/main/groovy/js/npm-cli.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/js/npm-publish-tasks.gradle
+++ b/buildSrc/src/main/groovy/js/npm-publish-tasks.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/js/update-package-version.gradle
+++ b/buildSrc/src/main/groovy/js/update-package-version.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/license-report-common.gradle
+++ b/buildSrc/src/main/groovy/license-report-common.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/buildSrc/src/main/groovy/license-report-project.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/license-report-repo.gradle
+++ b/buildSrc/src/main/groovy/license-report-repo.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/model-compiler.gradle
+++ b/buildSrc/src/main/groovy/model-compiler.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/pmd.gradle
+++ b/buildSrc/src/main/groovy/pmd.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/publish-proto.gradle
+++ b/buildSrc/src/main/groovy/publish-proto.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/publish.gradle
+++ b/buildSrc/src/main/groovy/publish.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/run-build.gradle
+++ b/buildSrc/src/main/groovy/run-build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/slow-tests.gradle
+++ b/buildSrc/src/main/groovy/slow-tests.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/test-artifacts.gradle
+++ b/buildSrc/src/main/groovy/test-artifacts.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/test-output.gradle
+++ b/buildSrc/src/main/groovy/test-output.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/update-gh-pages.gradle
+++ b/buildSrc/src/main/groovy/update-gh-pages.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/codegen.gradle.kts
+++ b/buildSrc/src/main/kotlin/codegen.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/dart.gradle.kts
+++ b/buildSrc/src/main/kotlin/dart.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AppEngine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AppEngine.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AssertK.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AssertK.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoCommon.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoCommon.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoService.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoValue.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoValue.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/BouncyCastle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/BouncyCastle.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckerFramework.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckerFramework.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCli.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCli.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsLogging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsLogging.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/FindBugs.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/FindBugs.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Firebase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Firebase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaPoet.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaPoet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaX.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Klaxon.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Klaxon.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/LicenseReport.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/LicenseReport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Okio.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Okio.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Slf4J.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Slf4J.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Build.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Build.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/IncrementGuard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publishing.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Scripts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Scripts.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/client.dart
+++ b/client/lib/client.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/firebase_client.dart
+++ b/client/lib/firebase_client.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/http_client.dart
+++ b/client/lib/http_client.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/json.dart
+++ b/client/lib/json.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/known_types.dart
+++ b/client/lib/known_types.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/spine_client.dart
+++ b/client/lib/spine_client.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/src/actor_request_factory.dart
+++ b/client/lib/src/actor_request_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/src/any_packer.dart
+++ b/client/lib/src/any_packer.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/src/command_factory.dart
+++ b/client/lib/src/command_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/src/query_factory.dart
+++ b/client/lib/src/query_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/src/query_processor.dart
+++ b/client/lib/src/query_processor.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/src/target_builder.dart
+++ b/client/lib/src/target_builder.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/src/topic_factory.dart
+++ b/client/lib/src/topic_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/src/url.dart
+++ b/client/lib/src/url.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/subscription.dart
+++ b/client/lib/subscription.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/time.dart
+++ b/client/lib/time.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/unknown_type.dart
+++ b/client/lib/unknown_type.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/uuids.dart
+++ b/client/lib/uuids.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/lib/validate.dart
+++ b/client/lib/validate.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   pedantic: ^1.11.0
   test: ^1.17.4
-  dartdoc: ^1.0.0
+  dartdoc: ^5.0.0

--- a/client/test/actor_request_factory_test.dart
+++ b/client/test/actor_request_factory_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/test/any_packer_test.dart
+++ b/client/test/any_packer_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/test/client_test.dart
+++ b/client/test/client_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/test/fake_firebase_client.dart
+++ b/client/test/fake_firebase_client.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/test/filter_test.dart
+++ b/client/test/filter_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/test/generation_test.dart
+++ b/client/test/generation_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/test/json_test.dart
+++ b/client/test/json_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/test/target_builder_test.dart
+++ b/client/test/target_builder_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/test/time_test.dart
+++ b/client/test/time_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/test/validation_test.dart
+++ b/client/test/validation_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/bin/main.dart
+++ b/codegen/bin/main.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/dart_code_gen.dart
+++ b/codegen/lib/dart_code_gen.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/bytes_validator_factory.dart
+++ b/codegen/lib/src/bytes_validator_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/constraint_violation.dart
+++ b/codegen/lib/src/constraint_violation.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/enum_validator_factory.dart
+++ b/codegen/lib/src/enum_validator_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/field_validator_factory.dart
+++ b/codegen/lib/src/field_validator_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/imports.dart
+++ b/codegen/lib/src/imports.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/known_types_factory.dart
+++ b/codegen/lib/src/known_types_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/message_validator_factory.dart
+++ b/codegen/lib/src/message_validator_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/noop_validator_factory.dart
+++ b/codegen/lib/src/noop_validator_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/number_validator_factory.dart
+++ b/codegen/lib/src/number_validator_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/required_field_validation_factory.dart
+++ b/codegen/lib/src/required_field_validation_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/string_validator_factory.dart
+++ b/codegen/lib/src/string_validator_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/type.dart
+++ b/codegen/lib/src/type.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/lib/src/validator_factory.dart
+++ b/codegen/lib/src/validator_factory.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/client-test/build.gradle.kts
+++ b/integration-tests/client-test/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/client-test/integration-test/client_test.dart
+++ b/integration-tests/client-test/integration-test/client_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/client-test/integration-test/client_test.html
+++ b/integration-tests/client-test/integration-test/client_test.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021, TeamDev. All rights reserved.
+  ~ Copyright 2023, TeamDev. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/integration-tests/client-test/integration-test/dart_firebase_client.dart
+++ b/integration-tests/client-test/integration-test/dart_firebase_client.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/client-test/integration-test/endpoints.dart
+++ b/integration-tests/client-test/integration-test/endpoints.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/client-test/integration-test/firebase_app.dart
+++ b/integration-tests/client-test/integration-test/firebase_app.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/build.gradle.kts
+++ b/integration-tests/test-app/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/Application.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/PermissiveCorsFilter.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/PermissiveCorsFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectAggregate.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectProgressProjection.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectProgressProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectProgressRepository.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectProgressRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectRepository.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/ProjectRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/Server.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/TaskAggregate.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/TaskAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/TaskRepository.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/TaskRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestCommandServlet.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestCommandServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestDirectQueryServlet.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestDirectQueryServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestQueryServlet.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestQueryServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestSubscribeServlet.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestSubscribeServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestSubscriptionCancelServlet.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestSubscriptionCancelServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestSubscriptionKeepUpServlet.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/TestSubscriptionKeepUpServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/TidyClient.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/TidyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/UserTasksProjection.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/UserTasksProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/UserTasksProjectionRepository.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/UserTasksProjectionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/java/io/spine/web/test/given/package-info.java
+++ b/integration-tests/test-app/src/main/java/io/spine/web/test/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/proto/spine/web/test/given/commands.proto
+++ b/integration-tests/test-app/src/main/proto/spine/web/test/given/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/proto/spine/web/test/given/events.proto
+++ b/integration-tests/test-app/src/main/proto/spine/web/test/given/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/proto/spine/web/test/given/project.proto
+++ b/integration-tests/test-app/src/main/proto/spine/web/test/given/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/proto/spine/web/test/given/task.proto
+++ b/integration-tests/test-app/src/main/proto/spine/web/test/given/task.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/test-app/src/main/proto/spine/web/test/given/user_tasks.proto
+++ b/integration-tests/test-app/src/main/proto/spine/web/test/given/user_tasks.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/script/decrypt.sh
+++ b/script/decrypt.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright 2022, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,7 +32,7 @@
 /**
  * Version of this library.
  */
-val dart = "1.9.0-SNAPSHOT.12"
+val dart = "1.9.0-SNAPSHOT.13"
 
 /**
  * Versions of the Spine libraries that this library depends on.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@ val dart = "1.9.0-SNAPSHOT.12"
  * Versions of the Spine libraries that this library depends on.
  */
 val base = "1.9.0-SNAPSHOT.6"
-val web = "1.9.0-SNAPSHOT.12"
+val web = "1.9.0-SNAPSHOT.13"
 
 project.extra.apply {
     this["versionToPublish"] = dart

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -37,7 +37,7 @@ val dart = "1.9.0-SNAPSHOT.12"
 /**
  * Versions of the Spine libraries that this library depends on.
  */
-val base = "1.9.0-SNAPSHOT.5"
+val base = "1.9.0-SNAPSHOT.6"
 val web = "1.9.0-SNAPSHOT.12"
 
 project.extra.apply {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following


### PR DESCRIPTION
Change the year in copyright headers to `2023`.

Also, upgrade the dependencies of other Spine libraries to the latest snapshots.

Also, I updated the `dartdoc` dependency from `^1.0.0` to `^5.0.0` — the first version that supports null safety. Without this change, I got an error:
``` log
Because spine_client depends on dartdoc >=0.0.1 <5.0.0 which doesn't support null safety, version solving failed.
```